### PR TITLE
[Chore] Jacoco Coverage Test Action 추가

### DIFF
--- a/.github/workflows/ci-coverage.yaml
+++ b/.github/workflows/ci-coverage.yaml
@@ -33,5 +33,5 @@ jobs:
           title: 'Jacoco Test Coverage Report'
           paths: ${{ github.workspace }}/build/jacoco/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 0
-          min-coverage-changed-files: 0
+          min-coverage-overall: 80
+          min-coverage-changed-files: 80

--- a/.github/workflows/ci-coverage.yaml
+++ b/.github/workflows/ci-coverage.yaml
@@ -1,0 +1,37 @@
+name: Jacoco Coverage Test
+
+on:
+  pull_request:
+    branches:
+      ["main"]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Test with Gradle
+        run: ./gradlew build --info test
+
+      - name: Jacoco Test Coverage Report
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          title: 'Jacoco Test Coverage Report'
+          paths: ${{ github.workspace }}/build/jacoco/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 0
+          min-coverage-changed-files: 0

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'jacoco'
 }
 
 group = 'dev.cass.knorda'
@@ -27,12 +28,59 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Test dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
-tasks.named('test') {
+test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+jacocoTestReport {
+    // test task가 끝난 후 실행
+    dependsOn test
+
+    reports {
+        // 커버리지 테스트 결과를 xml, html 파일로 생성
+        xml.required.set(true)
+        html.required.set(true)
+
+        // xml, html 파일 생성 위치
+        xml.destination file(layout.buildDirectory.dir("jacoco/jacocoTestReport.xml"))
+        html.destination file(layout.buildDirectory.dir("jacoco/html"))
+    }
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            // 커버리지 체크 기준을 class로 설정
+            element = 'CLASS'
+
+            // Branch 커버리지가 80% 미만일 경우 실패
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            // Line 커버리지가 80% 미만일 경우 실패
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+        }
+    }
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/test/java/dev/cass/knorda/KnordaApplicationTests.java
+++ b/src/test/java/dev/cass/knorda/KnordaApplicationTests.java
@@ -29,7 +29,7 @@ import org.springframework.test.context.TestPropertySource;
  * - args: main 메소드에 전달할 인자를 지정
  */
 @TestPropertySource(properties = {"spring.config.location = classpath:application-test.yaml"})
-@SpringBootTest
+@SpringBootTest(useMainMethod = SpringBootTest.UseMainMethod.ALWAYS)
 class KnordaApplicationTests {
 
 	/**
@@ -39,10 +39,5 @@ class KnordaApplicationTests {
 	@Test
 	void contextLoads() {
 		assert true;
-	}
-
-	@Test
-	public void main() {
-		KnordaApplication.main(new String[] {});
 	}
 }

--- a/src/test/java/dev/cass/knorda/KnordaApplicationTests.java
+++ b/src/test/java/dev/cass/knorda/KnordaApplicationTests.java
@@ -2,8 +2,7 @@ package dev.cass.knorda;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
-
+import org.springframework.test.context.ActiveProfiles;
 
 /**
  * - TestPropertySource
@@ -12,6 +11,9 @@ import org.springframework.test.context.TestPropertySource;
  * TestPropertySource 어노테이션으로 로드한 properties는, JAVA 시스템에서, 애플리케이션 단위에서 (@PropertySource), 혹은 programmatically하게 선언한 속성 (ApplicationContextInitializer)보다 우선순위가 높음
  * 단, @DynamicPropertySource 어노테이션으로 로드한 properties는, TestPropertySource 어노테이션으로 로드한 properties보다 우선순위가 높음
  * 즉, test/resources/application-test.yaml 파일을 로드하고, 해당 파일에 선언된 properties를 사용할 것임을 명시
+ *
+ * - ActiveProfiles
+ * 활성화할 프로파일을 지정하는 어노테이션
  *
  * - SpringBootTest
  * spring-boot-test 라이브러리에서 제공하는 어노테이션
@@ -28,7 +30,7 @@ import org.springframework.test.context.TestPropertySource;
  * - useMainMethod: main 메소드를 사용할 것인지 지정
  * - args: main 메소드에 전달할 인자를 지정
  */
-@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yaml"})
+@ActiveProfiles("test")
 @SpringBootTest(useMainMethod = SpringBootTest.UseMainMethod.ALWAYS)
 class KnordaApplicationTests {
 

--- a/src/test/java/dev/cass/knorda/KnordaApplicationTests.java
+++ b/src/test/java/dev/cass/knorda/KnordaApplicationTests.java
@@ -2,8 +2,18 @@ package dev.cass.knorda;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
 
 /**
+ * - TestPropertySource
+ * JUnit5에서 제공하는 어노테이션
+ * 통합 테스트를 위해서, 어노테이션에 선언한 환경 파일과 inlined properties를 Application Context에 로드
+ * TestPropertySource 어노테이션으로 로드한 properties는, JAVA 시스템에서, 애플리케이션 단위에서 (@PropertySource), 혹은 programmatically하게 선언한 속성 (ApplicationContextInitializer)보다 우선순위가 높음
+ * 단, @DynamicPropertySource 어노테이션으로 로드한 properties는, TestPropertySource 어노테이션으로 로드한 properties보다 우선순위가 높음
+ * 즉, test/resources/application-test.yaml 파일을 로드하고, 해당 파일에 선언된 properties를 사용할 것임을 명시
+ *
+ * - SpringBootTest
  * spring-boot-test 라이브러리에서 제공하는 어노테이션
  * 스프링의 전체 컨텍스트를 로드하여 테스트를 진행하게 해 줌
  * - 특정 빈이나 서비스를 모킹하기 위해서는 @MockBean을 사용해서 목 객체를 주입해야 함
@@ -18,6 +28,7 @@ import org.springframework.boot.test.context.SpringBootTest;
  * - useMainMethod: main 메소드를 사용할 것인지 지정
  * - args: main 메소드에 전달할 인자를 지정
  */
+@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yaml"})
 @SpringBootTest
 class KnordaApplicationTests {
 
@@ -28,5 +39,10 @@ class KnordaApplicationTests {
 	@Test
 	void contextLoads() {
 		assert true;
+	}
+
+	@Test
+	public void main() {
+		KnordaApplication.main(new String[] {});
 	}
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -4,3 +4,8 @@ spring:
     driverClassName: org.h2.Driver
     username: sa
     password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL
+    driverClassName: org.h2.Driver
+    username: sa
+    password:


### PR DESCRIPTION
## 작업 내역 개요
Jacoco Coverage Test를 위한 환경과 Action 파일을 추가.
- lombok 어노테이션으로 생성하는 코드는 테스트에서 제외하도록 lombok.config를 추가하여 Gererated 어노테이션이 붙도록 함
- 테스트 시에 H2 Database를 사용할 수 있도록 application-test.yaml 설정 파일을 추가하고 test 종속성에 h2를 추가
- gradle에 커버리지 테스트 기준을 추가
- main Branch에 PR시 Coverage Test를 수행하고 이를 commend에 추가하도록 github action 추가
- gradle의 `test` 태스크 블록을 다른 태스크 블록과 동일한 형식으로 수정