### PR TITLE
[Feature] 상품 기능 API 추가

### DIFF
--- a/src/main/java/dev/cass/knorda/api/member/controller/MemberController.java
+++ b/src/main/java/dev/cass/knorda/api/member/controller/MemberController.java
@@ -55,12 +55,12 @@ public class MemberController {
 	@GetMapping("/members/me")
 	public ResponseEntity<RegisterDto.GetMemberResponse> getLoggedInMember(HttpSession session) {
 		int memberId = SessionManageUtils.getMemberId(session);
-		return ResponseEntity.status(HttpStatus.OK).body(memberService.findMemberByMemberId(memberId));
+		return ResponseEntity.status(HttpStatus.OK).body(memberService.findMemberResponseByMemberId(memberId));
 	}
 
 	@GetMapping("/members/{memberId}")
 	public ResponseEntity<RegisterDto.GetMemberResponse> getMember(@PathVariable int memberId) {
-		return ResponseEntity.status(HttpStatus.OK).body(memberService.findMemberByMemberId(memberId));
+		return ResponseEntity.status(HttpStatus.OK).body(memberService.findMemberResponseByMemberId(memberId));
 	}
 
 	/**

--- a/src/main/java/dev/cass/knorda/api/member/controller/MemberController.java
+++ b/src/main/java/dev/cass/knorda/api/member/controller/MemberController.java
@@ -101,8 +101,8 @@ public class MemberController {
 
 	@DeleteMapping("/members/{memberId}")
 	public ResponseEntity<Void> deleteMember(HttpSession session, @PathVariable int memberId) {
-		String loggedInUser = SessionManageUtils.getMemberName(session);
-		memberService.deleteMember(memberId, loggedInUser);
+		String loggedInMember = SessionManageUtils.getMemberName(session);
+		memberService.deleteMember(memberId, loggedInMember);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 

--- a/src/main/java/dev/cass/knorda/api/member/service/AuthService.java
+++ b/src/main/java/dev/cass/knorda/api/member/service/AuthService.java
@@ -30,7 +30,7 @@ public class AuthService {
 
 		memberRepository.save(member);
 
-		SessionManageUtils.addSession(session, SessionManageUtils.SESSION_USER, AuthDto.SessionDto.of(member));
+		SessionManageUtils.addSession(session, SessionManageUtils.SESSION_MEMBER, AuthDto.SessionDto.of(member));
 
 		return new AuthDto.LoginResponse(member.getMemberName());
 	}

--- a/src/main/java/dev/cass/knorda/api/member/service/MemberService.java
+++ b/src/main/java/dev/cass/knorda/api/member/service/MemberService.java
@@ -51,7 +51,7 @@ public class MemberService {
 	}
 
 	@Transactional(readOnly = true)
-	public RegisterDto.GetMemberResponse findMemberByMemberId(int memberId) {
+	public RegisterDto.GetMemberResponse findMemberResponseByMemberId(int memberId) {
 		Member member = memberRepository.findFirstByMemberId(memberId)
 			.orElseThrow(MemberNotFoundException::new);
 		return RegisterDto.GetMemberResponse.of(member);
@@ -87,5 +87,11 @@ public class MemberService {
 			.orElseThrow(MemberNotFoundException::new);
 		member.delete(modifier);
 		memberRepository.save(member);
+	}
+
+	@Transactional(readOnly = true)
+	public Member findMemberByMemberName(String memberName) {
+		return memberRepository.findFirstByMemberName(memberName)
+			.orElseThrow(MemberNotFoundException::new);
 	}
 }

--- a/src/main/java/dev/cass/knorda/api/product/controller/ProductController.java
+++ b/src/main/java/dev/cass/knorda/api/product/controller/ProductController.java
@@ -37,20 +37,17 @@ public class ProductController {
 
 	@DeleteMapping("/products/{productId}")
 	public ResponseEntity<Void> deleteProduct(@PathVariable int productId, HttpSession session) {
-		String loggedInUser = SessionManageUtils.getMemberName(session);
-		productFacade.deleteProduct(productId, loggedInUser);
+		String loggedInMember = SessionManageUtils.getMemberName(session);
+		productFacade.deleteProduct(productId, loggedInMember);
 		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 
 	@PutMapping("/products/{productId}")
-	public ResponseEntity<ProductRegisterDto.RegisterResponse> updateProduct(
-		@PathVariable int productId,
-		@RequestBody @Valid ProductRegisterDto.RegisterRequest registerRequest,
-		HttpSession session
-	) {
-		String loggedInUser = SessionManageUtils.getMemberName(session);
+	public ResponseEntity<ProductRegisterDto.RegisterResponse> updateProduct(@PathVariable int productId,
+		@RequestBody @Valid ProductRegisterDto.RegisterRequest registerRequest, HttpSession session) {
+		String loggedInMember = SessionManageUtils.getMemberName(session);
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(productFacade.updateProduct(productId, registerRequest, loggedInUser));
+			.body(productFacade.updateProduct(productId, registerRequest, loggedInMember));
 	}
 
 	@GetMapping("/products")
@@ -58,9 +55,7 @@ public class ProductController {
 		@RequestParam(required = false, name = "productName") String productName,
 		@RequestParam(required = false, name = "memberName") String memberName,
 		@RequestParam(required = false, name = "startDateTime") @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime startDateTime,
-		@RequestParam(required = false, name = "endDateTime") @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime endDateTime
-	) {
-
+		@RequestParam(required = false, name = "endDateTime") @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime endDateTime) {
 		ProductFindDto.GetProductQuery productQuery = ProductFindDto.GetProductQuery.builder()
 			.productName(productName)
 			.memberName(memberName)
@@ -74,8 +69,8 @@ public class ProductController {
 	@PostMapping("/products")
 	public ResponseEntity<ProductRegisterDto.RegisterResponse> registerProduct(
 		@RequestBody @Valid ProductRegisterDto.RegisterRequest registerRequest, HttpSession session) {
-		String loggedInUser = SessionManageUtils.getMemberName(session);
+		String loggedInMember = SessionManageUtils.getMemberName(session);
 		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(productFacade.registerProduct(registerRequest, loggedInUser));
+			.body(productFacade.registerProduct(registerRequest, loggedInMember));
 	}
 }

--- a/src/main/java/dev/cass/knorda/api/product/controller/ProductController.java
+++ b/src/main/java/dev/cass/knorda/api/product/controller/ProductController.java
@@ -1,0 +1,79 @@
+package dev.cass.knorda.api.product.controller;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import dev.cass.knorda.api.product.dto.ProductFindDto;
+import dev.cass.knorda.api.product.dto.ProductRegisterDto;
+import dev.cass.knorda.api.product.facade.ProductFacade;
+import dev.cass.knorda.global.controller.V1Controller;
+import dev.cass.knorda.global.util.SessionManageUtils;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@V1Controller
+public class ProductController {
+	private final ProductFacade productFacade;
+
+	@GetMapping("/products/{productId}")
+	public ResponseEntity<ProductFindDto.GetProductResponse> getProduct(@PathVariable int productId) {
+		return ResponseEntity.status(HttpStatus.OK).body(productFacade.getProductById(productId));
+	}
+
+	@DeleteMapping("/products/{productId}")
+	public ResponseEntity<Void> deleteProduct(@PathVariable int productId, HttpSession session) {
+		String loggedInUser = SessionManageUtils.getMemberName(session);
+		productFacade.deleteProduct(productId, loggedInUser);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+	}
+
+	@PutMapping("/products/{productId}")
+	public ResponseEntity<ProductRegisterDto.response> updateProduct(
+		@PathVariable int productId,
+		@RequestBody @Valid ProductRegisterDto.request request,
+		HttpSession session
+	) {
+		String loggedInUser = SessionManageUtils.getMemberName(session);
+		return ResponseEntity.status(HttpStatus.OK).body(productFacade.updateProduct(productId, request, loggedInUser));
+	}
+
+	@GetMapping("/products")
+	public ResponseEntity<List<ProductFindDto.GetProductResponse>> getProductList(
+		@RequestParam(required = false, name = "productName") String productName,
+		@RequestParam(required = false, name = "memberName") String memberName,
+		@RequestParam(required = false, name = "startDateTime") @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime startDateTime,
+		@RequestParam(required = false, name = "endDateTime") @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime endDateTime
+	) {
+
+		ProductFindDto.GetProductQuery productQuery = ProductFindDto.GetProductQuery.builder()
+			.productName(productName)
+			.memberName(memberName)
+			.startDateTime(startDateTime)
+			.endDateTime(endDateTime)
+			.build();
+
+		return ResponseEntity.status(HttpStatus.OK).body(productFacade.getProductListByQuery(productQuery));
+	}
+
+	@PostMapping("/products")
+	public ResponseEntity<ProductRegisterDto.response> registerProduct(
+		@RequestBody @Valid ProductRegisterDto.request request, HttpSession session) {
+		String loggedInUser = SessionManageUtils.getMemberName(session);
+		return ResponseEntity.status(HttpStatus.CREATED).body(productFacade.registerProduct(request, loggedInUser));
+	}
+}

--- a/src/main/java/dev/cass/knorda/api/product/controller/ProductController.java
+++ b/src/main/java/dev/cass/knorda/api/product/controller/ProductController.java
@@ -43,13 +43,14 @@ public class ProductController {
 	}
 
 	@PutMapping("/products/{productId}")
-	public ResponseEntity<ProductRegisterDto.response> updateProduct(
+	public ResponseEntity<ProductRegisterDto.RegisterResponse> updateProduct(
 		@PathVariable int productId,
-		@RequestBody @Valid ProductRegisterDto.request request,
+		@RequestBody @Valid ProductRegisterDto.RegisterRequest registerRequest,
 		HttpSession session
 	) {
 		String loggedInUser = SessionManageUtils.getMemberName(session);
-		return ResponseEntity.status(HttpStatus.OK).body(productFacade.updateProduct(productId, request, loggedInUser));
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(productFacade.updateProduct(productId, registerRequest, loggedInUser));
 	}
 
 	@GetMapping("/products")
@@ -71,9 +72,10 @@ public class ProductController {
 	}
 
 	@PostMapping("/products")
-	public ResponseEntity<ProductRegisterDto.response> registerProduct(
-		@RequestBody @Valid ProductRegisterDto.request request, HttpSession session) {
+	public ResponseEntity<ProductRegisterDto.RegisterResponse> registerProduct(
+		@RequestBody @Valid ProductRegisterDto.RegisterRequest registerRequest, HttpSession session) {
 		String loggedInUser = SessionManageUtils.getMemberName(session);
-		return ResponseEntity.status(HttpStatus.CREATED).body(productFacade.registerProduct(request, loggedInUser));
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(productFacade.registerProduct(registerRequest, loggedInUser));
 	}
 }

--- a/src/main/java/dev/cass/knorda/api/product/dto/ProductFindDto.java
+++ b/src/main/java/dev/cass/knorda/api/product/dto/ProductFindDto.java
@@ -1,0 +1,71 @@
+package dev.cass.knorda.api.product.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import dev.cass.knorda.api.product.exception.InvalidQueryException;
+import dev.cass.knorda.domain.product.Product;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductFindDto {
+
+	@Getter
+	@AllArgsConstructor
+	public static class GetProductResponse {
+		private int productId;
+		private String name;
+		private String imageUrl;
+		private String description;
+		private String registerMemberName;
+
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+		private LocalDateTime registerDate;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+		private LocalDateTime updateDate;
+
+		public static GetProductResponse of(Product product) {
+			return new GetProductResponse(product.getProductId(), product.getName(), product.getImageUrl(),
+				product.getDescription(), product.getMember().getMemberName(), product.getCreatedAt(),
+				product.getModifiedAt());
+		}
+	}
+
+	@Getter
+	public static class GetProductQuery {
+		private final String productName;
+		private final String memberName;
+		private final LocalDateTime startDateTime;
+		private final LocalDateTime endDateTime;
+
+		@Builder
+		public GetProductQuery(String productName, String memberName, LocalDateTime startDateTime,
+			LocalDateTime endDateTime) {
+			this.productName = productName;
+			this.memberName = memberName;
+			this.startDateTime = startDateTime;
+			this.endDateTime = endDateTime;
+
+			// query 값 중 적어도 한 개 이상은 null이 아니여야 함
+			if (productName == null && memberName == null && startDateTime == null && endDateTime == null) {
+				throw new InvalidQueryException("query 값 중 적어도 한 개 이상은 null이 아니여야 합니다.");
+			}
+
+			// startDateTime과 endDateTime은 모두 null이거나 모두 null이 아니여야 함
+			if (startDateTime == null ^ endDateTime == null) {
+				throw new InvalidQueryException("startDateTime과 endDateTime은 모두 null이거나 모두 null이 아니여야 합니다.");
+			}
+
+			// startDateTime이 null이 아니라면, endDateTime보다 앞이여야 함
+			if (startDateTime != null && startDateTime.isAfter(endDateTime)) {
+				throw new InvalidQueryException("startDateTime은 endDateTime보다 앞이여야 합니다.");
+			}
+		}
+	}
+
+}

--- a/src/main/java/dev/cass/knorda/api/product/dto/ProductRegisterDto.java
+++ b/src/main/java/dev/cass/knorda/api/product/dto/ProductRegisterDto.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 public class ProductRegisterDto {
 	@Getter
 	@AllArgsConstructor
-	public static class request {
+	public static class RegisterRequest {
 		@NotNull
 		private String productName;
 		@NotNull
@@ -31,15 +31,15 @@ public class ProductRegisterDto {
 
 	@Getter
 	@AllArgsConstructor
-	public static class response {
+	public static class RegisterResponse {
 		private int productId;
 		private String productName;
 		private String description;
 		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
 		private LocalDateTime registerDate;
 
-		public static response of(Product product) {
-			return new response(
+		public static RegisterResponse of(Product product) {
+			return new RegisterResponse(
 				product.getProductId(),
 				product.getName(),
 				product.getDescription(),

--- a/src/main/java/dev/cass/knorda/api/product/dto/ProductRegisterDto.java
+++ b/src/main/java/dev/cass/knorda/api/product/dto/ProductRegisterDto.java
@@ -1,0 +1,50 @@
+package dev.cass.knorda.api.product.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import dev.cass.knorda.domain.product.Product;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductRegisterDto {
+	@Getter
+	@AllArgsConstructor
+	public static class request {
+		@NotNull
+		private String productName;
+		@NotNull
+		private String description;
+
+		public Product toEntity() {
+			return Product.builder()
+				.name(productName)
+				.description(description)
+				.build();
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class response {
+		private int productId;
+		private String productName;
+		private String description;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+		private LocalDateTime registerDate;
+
+		public static response of(Product product) {
+			return new response(
+				product.getProductId(),
+				product.getName(),
+				product.getDescription(),
+				product.getCreatedAt()
+			);
+		}
+	}
+}

--- a/src/main/java/dev/cass/knorda/api/product/exception/AlreadyExistProductNameException.java
+++ b/src/main/java/dev/cass/knorda/api/product/exception/AlreadyExistProductNameException.java
@@ -1,0 +1,11 @@
+package dev.cass.knorda.api.product.exception;
+
+import org.springframework.http.HttpStatus;
+
+import dev.cass.knorda.global.exception1.BusinessException;
+
+public class AlreadyExistProductNameException extends BusinessException {
+	public AlreadyExistProductNameException() {
+		super(HttpStatus.BAD_REQUEST, "이미 존재하는 상품명입니다.");
+	}
+}

--- a/src/main/java/dev/cass/knorda/api/product/exception/InvalidQueryException.java
+++ b/src/main/java/dev/cass/knorda/api/product/exception/InvalidQueryException.java
@@ -1,0 +1,11 @@
+package dev.cass.knorda.api.product.exception;
+
+import org.springframework.http.HttpStatus;
+
+import dev.cass.knorda.global.exception1.BusinessException;
+
+public class InvalidQueryException extends BusinessException {
+	public InvalidQueryException(String message) {
+		super(HttpStatus.BAD_REQUEST, message);
+	}
+}

--- a/src/main/java/dev/cass/knorda/api/product/exception/NotYourProductException.java
+++ b/src/main/java/dev/cass/knorda/api/product/exception/NotYourProductException.java
@@ -1,0 +1,11 @@
+package dev.cass.knorda.api.product.exception;
+
+import org.springframework.http.HttpStatus;
+
+import dev.cass.knorda.global.exception1.BusinessException;
+
+public class NotYourProductException extends BusinessException {
+	public NotYourProductException() {
+		super(HttpStatus.UNAUTHORIZED, "자신의 상품이 아니라서 변경할 수 없습니다.");
+	}
+}

--- a/src/main/java/dev/cass/knorda/api/product/exception/ProductNotExistException.java
+++ b/src/main/java/dev/cass/knorda/api/product/exception/ProductNotExistException.java
@@ -1,0 +1,11 @@
+package dev.cass.knorda.api.product.exception;
+
+import org.springframework.http.HttpStatus;
+
+import dev.cass.knorda.global.exception1.BusinessException;
+
+public class ProductNotExistException extends BusinessException {
+	public ProductNotExistException() {
+		super(HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다.");
+	}
+}

--- a/src/main/java/dev/cass/knorda/api/product/exception/ProductNotOwnedByLoggedInMemberException.java
+++ b/src/main/java/dev/cass/knorda/api/product/exception/ProductNotOwnedByLoggedInMemberException.java
@@ -4,8 +4,8 @@ import org.springframework.http.HttpStatus;
 
 import dev.cass.knorda.global.exception1.BusinessException;
 
-public class NotYourProductException extends BusinessException {
-	public NotYourProductException() {
+public class ProductNotOwnedByLoggedInMemberException extends BusinessException {
+	public ProductNotOwnedByLoggedInMemberException() {
 		super(HttpStatus.UNAUTHORIZED, "자신의 상품이 아니라서 변경할 수 없습니다.");
 	}
 }

--- a/src/main/java/dev/cass/knorda/api/product/facade/ProductFacade.java
+++ b/src/main/java/dev/cass/knorda/api/product/facade/ProductFacade.java
@@ -3,12 +3,13 @@ package dev.cass.knorda.api.product.facade;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import dev.cass.knorda.api.member.service.MemberService;
 import dev.cass.knorda.api.product.dto.ProductFindDto;
 import dev.cass.knorda.api.product.dto.ProductRegisterDto;
 import dev.cass.knorda.api.product.exception.AlreadyExistProductNameException;
-import dev.cass.knorda.api.product.exception.NotYourProductException;
+import dev.cass.knorda.api.product.exception.ProductNotOwnedByLoggedInMemberException;
 import dev.cass.knorda.api.product.service.ProductService;
 import dev.cass.knorda.domain.member.Member;
 import dev.cass.knorda.domain.product.Product;
@@ -24,38 +25,40 @@ public class ProductFacade {
 		return ProductFindDto.GetProductResponse.of(productService.findById(productId));
 	}
 
+	@Transactional
 	public ProductRegisterDto.RegisterResponse registerProduct(ProductRegisterDto.RegisterRequest registerRequest,
 		String memberName) {
-		Member member = memberService.findMemberByMemberName(memberName);
 		if (productService.isExistProductName(registerRequest.getProductName())) {
 			throw new AlreadyExistProductNameException();
 		}
-		return ProductRegisterDto.RegisterResponse.of(productService.save(registerRequest, member));
+		Member member = memberService.findMemberByMemberName(memberName);
+		Product product = registerRequest.toEntity();
+		product.setMember(member);
+		return ProductRegisterDto.RegisterResponse.of(productService.save(product));
 	}
 
 	public List<ProductFindDto.GetProductResponse> getProductListByQuery(ProductFindDto.GetProductQuery productQuery) {
-		return productService.findAllByQuery(productQuery).stream()
-			.map(ProductFindDto.GetProductResponse::of)
-			.toList();
+		return productService.findAllByQuery(productQuery).stream().map(ProductFindDto.GetProductResponse::of).toList();
 	}
 
-	public void deleteProduct(int productId, String loggedInUser) {
+	@Transactional
+	public void deleteProduct(int productId, String loggedInMember) {
 		Product product = productService.findById(productId);
-		if (!product.getMember().getMemberName().equals(loggedInUser)) {
-			throw new NotYourProductException();
+		if (!product.getMember().getMemberName().equals(loggedInMember)) {
+			throw new ProductNotOwnedByLoggedInMemberException();
 		}
 		productService.delete(product);
 	}
 
+	@Transactional
 	public ProductRegisterDto.RegisterResponse updateProduct(int productId,
-		ProductRegisterDto.RegisterRequest registerRequest,
-		String loggedInUser) {
+		ProductRegisterDto.RegisterRequest registerRequest, String loggedInMember) {
 		Product product = productService.findById(productId);
-		if (!product.getMember().getMemberName().equals(loggedInUser)) {
-			throw new NotYourProductException();
+		if (!product.getMember().getMemberName().equals(loggedInMember)) {
+			throw new ProductNotOwnedByLoggedInMemberException();
 		}
-		if (!product.getName().equals(registerRequest.getProductName()) && productService.isExistProductName(
-			registerRequest.getProductName())) {
+		if (!product.getName().equals(registerRequest.getProductName())
+			&& productService.isExistProductName(registerRequest.getProductName())) {
 			throw new AlreadyExistProductNameException();
 		}
 		return ProductRegisterDto.RegisterResponse.of(productService.update(product, registerRequest));

--- a/src/main/java/dev/cass/knorda/api/product/facade/ProductFacade.java
+++ b/src/main/java/dev/cass/knorda/api/product/facade/ProductFacade.java
@@ -24,12 +24,13 @@ public class ProductFacade {
 		return ProductFindDto.GetProductResponse.of(productService.findById(productId));
 	}
 
-	public ProductRegisterDto.response registerProduct(ProductRegisterDto.request request, String memberName) {
+	public ProductRegisterDto.RegisterResponse registerProduct(ProductRegisterDto.RegisterRequest registerRequest,
+		String memberName) {
 		Member member = memberService.findMemberByMemberName(memberName);
-		if (productService.isExistProductName(request.getProductName())) {
+		if (productService.isExistProductName(registerRequest.getProductName())) {
 			throw new AlreadyExistProductNameException();
 		}
-		return ProductRegisterDto.response.of(productService.save(request, member));
+		return ProductRegisterDto.RegisterResponse.of(productService.save(registerRequest, member));
 	}
 
 	public List<ProductFindDto.GetProductResponse> getProductListByQuery(ProductFindDto.GetProductQuery productQuery) {
@@ -46,16 +47,17 @@ public class ProductFacade {
 		productService.delete(product);
 	}
 
-	public ProductRegisterDto.response updateProduct(int productId, ProductRegisterDto.request request,
+	public ProductRegisterDto.RegisterResponse updateProduct(int productId,
+		ProductRegisterDto.RegisterRequest registerRequest,
 		String loggedInUser) {
 		Product product = productService.findById(productId);
 		if (!product.getMember().getMemberName().equals(loggedInUser)) {
 			throw new NotYourProductException();
 		}
-		if (!product.getName().equals(request.getProductName()) && productService.isExistProductName(
-			request.getProductName())) {
+		if (!product.getName().equals(registerRequest.getProductName()) && productService.isExistProductName(
+			registerRequest.getProductName())) {
 			throw new AlreadyExistProductNameException();
 		}
-		return ProductRegisterDto.response.of(productService.update(product, request));
+		return ProductRegisterDto.RegisterResponse.of(productService.update(product, registerRequest));
 	}
 }

--- a/src/main/java/dev/cass/knorda/api/product/facade/ProductFacade.java
+++ b/src/main/java/dev/cass/knorda/api/product/facade/ProductFacade.java
@@ -1,0 +1,61 @@
+package dev.cass.knorda.api.product.facade;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import dev.cass.knorda.api.member.service.MemberService;
+import dev.cass.knorda.api.product.dto.ProductFindDto;
+import dev.cass.knorda.api.product.dto.ProductRegisterDto;
+import dev.cass.knorda.api.product.exception.AlreadyExistProductNameException;
+import dev.cass.knorda.api.product.exception.NotYourProductException;
+import dev.cass.knorda.api.product.service.ProductService;
+import dev.cass.knorda.domain.member.Member;
+import dev.cass.knorda.domain.product.Product;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ProductFacade {
+	private final ProductService productService;
+	private final MemberService memberService;
+
+	public ProductFindDto.GetProductResponse getProductById(int productId) {
+		return ProductFindDto.GetProductResponse.of(productService.findById(productId));
+	}
+
+	public ProductRegisterDto.response registerProduct(ProductRegisterDto.request request, String memberName) {
+		Member member = memberService.findMemberByMemberName(memberName);
+		if (productService.isExistProductName(request.getProductName())) {
+			throw new AlreadyExistProductNameException();
+		}
+		return ProductRegisterDto.response.of(productService.save(request, member));
+	}
+
+	public List<ProductFindDto.GetProductResponse> getProductListByQuery(ProductFindDto.GetProductQuery productQuery) {
+		return productService.findAllByQuery(productQuery).stream()
+			.map(ProductFindDto.GetProductResponse::of)
+			.toList();
+	}
+
+	public void deleteProduct(int productId, String loggedInUser) {
+		Product product = productService.findById(productId);
+		if (!product.getMember().getMemberName().equals(loggedInUser)) {
+			throw new NotYourProductException();
+		}
+		productService.delete(product);
+	}
+
+	public ProductRegisterDto.response updateProduct(int productId, ProductRegisterDto.request request,
+		String loggedInUser) {
+		Product product = productService.findById(productId);
+		if (!product.getMember().getMemberName().equals(loggedInUser)) {
+			throw new NotYourProductException();
+		}
+		if (!product.getName().equals(request.getProductName()) && productService.isExistProductName(
+			request.getProductName())) {
+			throw new AlreadyExistProductNameException();
+		}
+		return ProductRegisterDto.response.of(productService.update(product, request));
+	}
+}

--- a/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
+++ b/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
@@ -1,0 +1,80 @@
+package dev.cass.knorda.api.product.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import dev.cass.knorda.api.product.dto.ProductFindDto;
+import dev.cass.knorda.api.product.dto.ProductRegisterDto;
+import dev.cass.knorda.api.product.exception.ProductNotExistException;
+import dev.cass.knorda.domain.member.Member;
+import dev.cass.knorda.domain.product.Product;
+import dev.cass.knorda.domain.product.ProductRepository;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+	private final ProductRepository productRepository;
+
+	@Transactional(readOnly = true)
+	public Product findById(int productId) {
+		return productRepository.findFirstByProductId(productId).orElseThrow(ProductNotExistException::new);
+	}
+
+	public Product save(ProductRegisterDto.request request, Member member) {
+		Product product = request.toEntity();
+		product.setMember(member);
+		return productRepository.save(product);
+	}
+
+	public void delete(Product product) {
+		product.delete();
+		productRepository.save(product);
+	}
+
+	public Product update(Product product, ProductRegisterDto.request request) {
+		product.update(request.getProductName(), request.getDescription());
+		return productRepository.save(product);
+	}
+
+	@Transactional(readOnly = true)
+	public boolean isExistProductName(String productName) {
+		return productRepository.findFirstByNameAndIsDeletedFalse(productName).isPresent();
+	}
+
+	@Transactional(readOnly = true)
+	public List<Product> findAllByQuery(ProductFindDto.GetProductQuery productQuery) {
+		Specification<Product> specification = (root, query, criteriaBuilder) -> {
+			List<jakarta.persistence.criteria.Predicate> predicates = new ArrayList<>();
+
+			root.fetch("member", JoinType.LEFT);
+
+			if (productQuery.getProductName() != null) {
+				predicates.add(criteriaBuilder.equal(root.get("name"), productQuery.getProductName()));
+			}
+
+			if (productQuery.getMemberName() != null) {
+				predicates.add(
+					criteriaBuilder.equal(root.get("member").get("memberName"), productQuery.getMemberName()));
+			}
+
+			if (productQuery.getStartDateTime() != null) {
+				predicates.add(
+					criteriaBuilder.greaterThanOrEqualTo(root.get("createdAt"), productQuery.getStartDateTime()));
+				predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("createdAt"), productQuery.getEndDateTime()));
+			}
+
+			predicates.add(criteriaBuilder.isFalse(root.get("isDeleted")));
+
+			return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+		};
+		return productRepository.findAll(specification);
+	}
+
+}

--- a/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
+++ b/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
@@ -27,8 +27,8 @@ public class ProductService {
 		return productRepository.findFirstByProductId(productId).orElseThrow(ProductNotExistException::new);
 	}
 
-	public Product save(ProductRegisterDto.request request, Member member) {
-		Product product = request.toEntity();
+	public Product save(ProductRegisterDto.RegisterRequest registerRequest, Member member) {
+		Product product = registerRequest.toEntity();
 		product.setMember(member);
 		return productRepository.save(product);
 	}
@@ -38,8 +38,8 @@ public class ProductService {
 		productRepository.save(product);
 	}
 
-	public Product update(Product product, ProductRegisterDto.request request) {
-		product.update(request.getProductName(), request.getDescription());
+	public Product update(Product product, ProductRegisterDto.RegisterRequest registerRequest) {
+		product.update(registerRequest.getProductName(), registerRequest.getDescription());
 		return productRepository.save(product);
 	}
 

--- a/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
+++ b/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
@@ -30,7 +30,7 @@ public class ProductService {
 	public Product save(ProductRegisterDto.RegisterRequest registerRequest, Member member) {
 		Product product = registerRequest.toEntity();
 		product.setMember(member);
-		return productRepository.save(product);
+		return productRepository.saveAndFlush(product);
 	}
 
 	public void delete(Product product) {
@@ -40,12 +40,12 @@ public class ProductService {
 
 	public Product update(Product product, ProductRegisterDto.RegisterRequest registerRequest) {
 		product.update(registerRequest.getProductName(), registerRequest.getDescription());
-		return productRepository.save(product);
+		return productRepository.saveAndFlush(product);
 	}
 
 	@Transactional(readOnly = true)
 	public boolean isExistProductName(String productName) {
-		return productRepository.findFirstByNameAndIsDeletedFalse(productName).isPresent();
+		return productRepository.existsByName(productName);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
+++ b/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
@@ -2,15 +2,13 @@ package dev.cass.knorda.api.product.service;
 
 import java.util.List;
 
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import dev.cass.knorda.api.product.dto.ProductFindDto;
-import dev.cass.knorda.api.product.dto.ProductRegisterDto;
 import dev.cass.knorda.api.product.exception.ProductNotExistException;
 import dev.cass.knorda.domain.product.Product;
 import dev.cass.knorda.domain.product.ProductRepository;
-import dev.cass.knorda.domain.product.ProductSpecification;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -23,18 +21,15 @@ public class ProductService {
 		return productRepository.findFirstByProductId(productId).orElseThrow(ProductNotExistException::new);
 	}
 
+	@Transactional
 	public Product save(Product product) {
-		return productRepository.saveAndFlush(product);
+		return productRepository.save(product);
 	}
 
+	@Transactional
 	public void delete(Product product) {
 		product.delete();
 		productRepository.save(product);
-	}
-
-	public Product update(Product product, ProductRegisterDto.RegisterRequest registerRequest) {
-		product.update(registerRequest.getProductName(), registerRequest.getDescription());
-		return productRepository.saveAndFlush(product);
 	}
 
 	@Transactional(readOnly = true)
@@ -43,8 +38,8 @@ public class ProductService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<Product> findAllByQuery(ProductFindDto.GetProductQuery productQuery) {
-		return productRepository.findAll(ProductSpecification.searchProductQuery(productQuery));
+	public List<Product> findAllByQuery(Specification<Product> productQuery) {
+		return productRepository.findAll(productQuery);
 	}
 
 }

--- a/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
+++ b/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
@@ -1,9 +1,7 @@
 package dev.cass.knorda.api.product.service;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,8 +11,7 @@ import dev.cass.knorda.api.product.exception.ProductNotExistException;
 import dev.cass.knorda.domain.member.Member;
 import dev.cass.knorda.domain.product.Product;
 import dev.cass.knorda.domain.product.ProductRepository;
-import jakarta.persistence.criteria.JoinType;
-import jakarta.persistence.criteria.Predicate;
+import dev.cass.knorda.domain.product.ProductSpecification;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -50,31 +47,7 @@ public class ProductService {
 
 	@Transactional(readOnly = true)
 	public List<Product> findAllByQuery(ProductFindDto.GetProductQuery productQuery) {
-		Specification<Product> specification = (root, query, criteriaBuilder) -> {
-			List<jakarta.persistence.criteria.Predicate> predicates = new ArrayList<>();
-
-			root.fetch("member", JoinType.LEFT);
-
-			if (productQuery.getProductName() != null) {
-				predicates.add(criteriaBuilder.equal(root.get("name"), productQuery.getProductName()));
-			}
-
-			if (productQuery.getMemberName() != null) {
-				predicates.add(
-					criteriaBuilder.equal(root.get("member").get("memberName"), productQuery.getMemberName()));
-			}
-
-			if (productQuery.getStartDateTime() != null) {
-				predicates.add(
-					criteriaBuilder.greaterThanOrEqualTo(root.get("createdAt"), productQuery.getStartDateTime()));
-				predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("createdAt"), productQuery.getEndDateTime()));
-			}
-
-			predicates.add(criteriaBuilder.isFalse(root.get("isDeleted")));
-
-			return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
-		};
-		return productRepository.findAll(specification);
+		return productRepository.findAll(ProductSpecification.searchProductQuery(productQuery));
 	}
 
 }

--- a/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
+++ b/src/main/java/dev/cass/knorda/api/product/service/ProductService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import dev.cass.knorda.api.product.dto.ProductFindDto;
 import dev.cass.knorda.api.product.dto.ProductRegisterDto;
 import dev.cass.knorda.api.product.exception.ProductNotExistException;
-import dev.cass.knorda.domain.member.Member;
 import dev.cass.knorda.domain.product.Product;
 import dev.cass.knorda.domain.product.ProductRepository;
 import dev.cass.knorda.domain.product.ProductSpecification;
@@ -24,9 +23,7 @@ public class ProductService {
 		return productRepository.findFirstByProductId(productId).orElseThrow(ProductNotExistException::new);
 	}
 
-	public Product save(ProductRegisterDto.RegisterRequest registerRequest, Member member) {
-		Product product = registerRequest.toEntity();
-		product.setMember(member);
+	public Product save(Product product) {
 		return productRepository.saveAndFlush(product);
 	}
 

--- a/src/main/java/dev/cass/knorda/domain/product/Product.java
+++ b/src/main/java/dev/cass/knorda/domain/product/Product.java
@@ -1,0 +1,80 @@
+package dev.cass.knorda.domain.product;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import dev.cass.knorda.domain.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "`product`")
+public class Product {
+
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "product_id")
+	@Id
+	private Integer productId;
+
+	/**
+	 * ManyToOne - 다대일 관계를 매핑할 때 사용
+	 * name (member_id) 컬럼 값을 가지고, 해당 값을 PK로 사용해서 해당하는 Member 엔티티를 찾아서 붙여줌
+	 * FetchType.LAZY - 지연 로딩. 해당 엔티티를 조회할 때, 연관된 엔티티를 조회하지 않고, 실제로 사용할 때 조회
+	 * (Product 엔티티를 조회했을 때는 member 엔티티가 null인 상태고, getMember() 메서드를 호출했을 때, 실제로 member 엔티티를 조회)
+	 * 이로 인해 발생하는 문제가 N+1 문제 (Product List를 조회했을 때, Product List 조회 시점에 Member List도 조회하게 되어, Member List 조회 쿼리가 N번 발생하는 현상)
+	 * 즉시 로딩 (FetchType.EAGER)을 설정하면, 해당 엔티티를 조회할 때 바로 조회하게 되어 N+1문제가 무조건 발생하고
+	 * 지연 로딩에서는 엔티티를 조회할 때는 바로 발생하지 않으나, 일대다 관계에서는 연관 엔티티 조회 시 발생할 수 있음
+	 * JoinColumn - 외래 키를 매핑할 때 사용
+	 */
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@Column(name = "name")
+	private String name;
+
+	@Column(name = "image_url")
+	private String imageUrl;
+
+	@Column(name = "description")
+	private String description;
+
+	@Column(name = "is_deleted")
+	private boolean isDeleted;
+
+	@CreatedDate
+	@Column(name = "created_at")
+	private LocalDateTime createdAt;
+
+	@Column(name = "modified_at")
+	private LocalDateTime modifiedAt;
+
+	public void delete() {
+		this.isDeleted = true;
+		this.modifiedAt = LocalDateTime.now();
+	}
+
+	public void update(String name, String description) {
+		this.name = name;
+		this.description = description;
+		this.modifiedAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/dev/cass/knorda/domain/product/ProductRepository.java
+++ b/src/main/java/dev/cass/knorda/domain/product/ProductRepository.java
@@ -18,6 +18,6 @@ public interface ProductRepository extends JpaRepository<Product, Integer>, JpaS
 	@EntityGraph(attributePaths = "member")
 	ArrayList<Product> findAllByMemberMemberId(int memberId);
 
-	Optional<Product> findFirstByNameAndIsDeletedFalse(String name);
+	boolean existsByName(String name);
 
 }

--- a/src/main/java/dev/cass/knorda/domain/product/ProductRepository.java
+++ b/src/main/java/dev/cass/knorda/domain/product/ProductRepository.java
@@ -1,0 +1,23 @@
+package dev.cass.knorda.domain.product;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface ProductRepository extends JpaRepository<Product, Integer>, JpaSpecificationExecutor<Product> {
+
+	Optional<Product> findFirstByProductId(int productId);
+
+	/**
+	 * EntityGraph - 연관된 엔티티를 함께 조회할 때 사용 (fetch join)
+	 * n+1문제를 방지하기 위해, 상품 리스트를 조회할 떄, fetch 조인을 사용해 member 엔티티도 함께 조회하겠다는 의미
+	 */
+	@EntityGraph(attributePaths = "member")
+	ArrayList<Product> findAllByMemberMemberId(int memberId);
+
+	Optional<Product> findFirstByNameAndIsDeletedFalse(String name);
+
+}

--- a/src/main/java/dev/cass/knorda/domain/product/ProductSpecification.java
+++ b/src/main/java/dev/cass/knorda/domain/product/ProductSpecification.java
@@ -1,0 +1,40 @@
+package dev.cass.knorda.domain.product;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import dev.cass.knorda.api.product.dto.ProductFindDto;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+
+public class ProductSpecification {
+
+	public static Specification<Product> searchProductQuery(ProductFindDto.GetProductQuery productQuery) {
+		return (root, query, criteriaBuilder) -> {
+			List<Predicate> predicates = new ArrayList<>();
+
+			root.fetch("member", JoinType.LEFT);
+
+			if (productQuery.getProductName() != null) {
+				predicates.add(criteriaBuilder.equal(root.get("name"), productQuery.getProductName()));
+			}
+
+			if (productQuery.getMemberName() != null) {
+				predicates.add(
+					criteriaBuilder.equal(root.get("member").get("memberName"), productQuery.getMemberName()));
+			}
+
+			if (productQuery.getStartDateTime() != null) {
+				predicates.add(
+					criteriaBuilder.greaterThanOrEqualTo(root.get("createdAt"), productQuery.getStartDateTime()));
+				predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("createdAt"), productQuery.getEndDateTime()));
+			}
+
+			predicates.add(criteriaBuilder.isFalse(root.get("isDeleted")));
+
+			return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+		};
+	}
+}

--- a/src/main/java/dev/cass/knorda/domain/product/ProductSpecification.java
+++ b/src/main/java/dev/cass/knorda/domain/product/ProductSpecification.java
@@ -8,7 +8,10 @@ import org.springframework.data.jpa.domain.Specification;
 import dev.cass.knorda.api.product.dto.ProductFindDto;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProductSpecification {
 
 	public static Specification<Product> searchProductQuery(ProductFindDto.GetProductQuery productQuery) {

--- a/src/main/java/dev/cass/knorda/global/exception1/GlobalExceptionHandler.java
+++ b/src/main/java/dev/cass/knorda/global/exception1/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package dev.cass.knorda.global.exception1;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -39,6 +40,12 @@ public class GlobalExceptionHandler {
 		}
 
 		return response(HttpStatus.BAD_REQUEST, message.toString());
+	}
+
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+		log.error("DataIntegrityViolationException : {}", e.getMessage());
+		return response(HttpStatus.BAD_REQUEST, "저장 시 오류가 발생하였습니다.");
 	}
 
 	private ResponseEntity<ErrorResponse> response(HttpStatus status, String message) {

--- a/src/main/java/dev/cass/knorda/global/util/SessionManageUtils.java
+++ b/src/main/java/dev/cass/knorda/global/util/SessionManageUtils.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Component
 public class SessionManageUtils {
 
-	public static final String SESSION_USER = "session_user";
+	public static final String SESSION_MEMBER = "session_member";
 
 	public static void invalidate(HttpSession session) {
 		session.invalidate();
@@ -29,8 +29,8 @@ public class SessionManageUtils {
 		return session.getAttribute(key);
 	}
 
-	public static AuthDto.SessionDto getSessionUser(HttpSession session) {
-		Object sessionObj = getSession(session, SESSION_USER);
+	public static AuthDto.SessionDto getSessionMember(HttpSession session) {
+		Object sessionObj = getSession(session, SESSION_MEMBER);
 		if (!(sessionObj instanceof AuthDto.SessionDto)) {
 			throw new NullSessionException();
 		}
@@ -38,10 +38,10 @@ public class SessionManageUtils {
 	}
 
 	public static String getMemberName(HttpSession session) {
-		return getSessionUser(session).getMemberName();
+		return getSessionMember(session).getMemberName();
 	}
 
 	public static int getMemberId(HttpSession session) {
-		return getSessionUser(session).getMemberId();
+		return getSessionMember(session).getMemberId();
 	}
 }

--- a/src/test/java/dev/cass/knorda/api/member/controller/AuthControllerTest.java
+++ b/src/test/java/dev/cass/knorda/api/member/controller/AuthControllerTest.java
@@ -26,14 +26,12 @@ import dev.cass.knorda.global.util.SessionManageUtils;
 
 @ExtendWith(MockitoExtension.class)
 class AuthControllerTest {
+	ObjectMapper objectMapper = new ObjectMapper();
 	@InjectMocks
 	private AuthController authController;
-
 	@Mock
 	private AuthService authService;
-
 	private MockMvc mockMvc;
-	ObjectMapper objectMapper = new ObjectMapper();
 	private MockHttpSession session = new MockHttpSession();
 
 	@BeforeEach
@@ -80,7 +78,7 @@ class AuthControllerTest {
 	@Test
 	void logout() throws Exception {
 		// Given
-		SessionManageUtils.addSession(session, SessionManageUtils.SESSION_USER, new AuthDto.SessionDto("admin", 1));
+		SessionManageUtils.addSession(session, SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto("admin", 1));
 
 		// When
 		ResultActions resultActions = mockMvc.perform(post("/api/v1/logout")

--- a/src/test/java/dev/cass/knorda/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/dev/cass/knorda/api/member/controller/MemberControllerTest.java
@@ -35,21 +35,19 @@ import dev.cass.knorda.global.util.SessionManageUtils;
 @ExtendWith(MockitoExtension.class)
 class MemberControllerTest {
 
+	ObjectMapper objectMapper = new ObjectMapper();
 	/**
 	 * InjectMocks - 테스트 대상이 되는 객체에 Mock 객체를 주입시키는 어노테이션
 	 * MemberController 객체를 생성하고, Mock 객체로 정의된 MemberService 객체를 주입시킨다
 	 */
 	@InjectMocks
 	private MemberController memberController;
-
 	/**
 	 * Mock - 해당 객체를 Mock 객체로 만들어주는 어노테이션
 	 */
 	@Mock
 	private MemberService memberService;
-
 	private MockMvc mockMvc;
-	ObjectMapper objectMapper = new ObjectMapper();
 
 	/**
 	 * BeforeEach - JUnit5에서 각 테스트 메소드가 실행되기 전에 실행되는 메소드를 지정하는 어노테이션
@@ -128,7 +126,7 @@ class MemberControllerTest {
 
 		// When
 		ResultActions resultActions = mockMvc.perform(get("/api/v1/members/me")
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, id)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, id)));
 
 		// Then
 		resultActions
@@ -154,7 +152,7 @@ class MemberControllerTest {
 		ResultActions resultActions = mockMvc.perform(get("/api/v1/members")
 			.param("page", "0")
 			.param("size", "10")
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, id)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, id)));
 
 		// Then
 		resultActions
@@ -176,7 +174,7 @@ class MemberControllerTest {
 
 		// When
 		ResultActions resultActions = mockMvc.perform(get("/api/v1/members/{memberId}", id)
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, id)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, id)));
 
 		// Then
 		resultActions
@@ -201,7 +199,7 @@ class MemberControllerTest {
 		ResultActions resultActions = mockMvc.perform(put("/api/v1/members")
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(updateMemberRequest))
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, id)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, id)));
 
 		// Then
 		resultActions
@@ -226,7 +224,7 @@ class MemberControllerTest {
 		ResultActions resultActions = mockMvc.perform(put("/api/v1/members/{memberId}", id)
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(updateMemberRequest))
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, id)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, id)));
 
 		// Then
 		resultActions
@@ -243,7 +241,7 @@ class MemberControllerTest {
 
 		// When
 		ResultActions resultActions = mockMvc.perform(delete("/api/v1/members")
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, id)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, id)));
 
 		// Then
 		resultActions
@@ -259,7 +257,7 @@ class MemberControllerTest {
 
 		// When
 		ResultActions resultActions = mockMvc.perform(delete("/api/v1/members/{memberId}", id)
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, id)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, id)));
 
 		// Then
 		resultActions
@@ -289,7 +287,7 @@ class MemberControllerTest {
 		ResultActions resultActions = mockMvc.perform(put("/api/v1/members/password")
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(changePasswordRequest))
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, id)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, id)));
 
 		// Then
 		resultActions
@@ -311,7 +309,7 @@ class MemberControllerTest {
 		ResultActions resultActions = mockMvc.perform(put("/api/v1/members/password")
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(changePasswordRequest))
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, id)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, id)));
 
 		// Then
 		resultActions

--- a/src/test/java/dev/cass/knorda/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/dev/cass/knorda/api/member/controller/MemberControllerTest.java
@@ -124,7 +124,7 @@ class MemberControllerTest {
 			null,
 			null);
 
-		doReturn(registerResponse).when(memberService).findMemberByMemberId(id);
+		doReturn(registerResponse).when(memberService).findMemberResponseByMemberId(id);
 
 		// When
 		ResultActions resultActions = mockMvc.perform(get("/api/v1/members/me")
@@ -172,7 +172,7 @@ class MemberControllerTest {
 			null,
 			null);
 
-		doReturn(registerResponse).when(memberService).findMemberByMemberId(id);
+		doReturn(registerResponse).when(memberService).findMemberResponseByMemberId(id);
 
 		// When
 		ResultActions resultActions = mockMvc.perform(get("/api/v1/members/{memberId}", id)

--- a/src/test/java/dev/cass/knorda/api/member/service/MemberServiceTest.java
+++ b/src/test/java/dev/cass/knorda/api/member/service/MemberServiceTest.java
@@ -217,13 +217,13 @@ class MemberServiceTest {
 
 	@DisplayName("사용자 id로 사용자 조회")
 	@Test
-	void findMemberByMemberName() {
+	void findMemberByMemberId() {
 		// given
 		Member member = Member.builder().memberId(1).memberName("admin").build();
 		doReturn(Optional.of(member)).when(memberRepository).findFirstByMemberId(1);
 
 		// when
-		RegisterDto.GetMemberResponse result = memberService.findMemberByMemberId(1);
+		RegisterDto.GetMemberResponse result = memberService.findMemberResponseByMemberId(1);
 
 		// then
 		assertEquals("admin", result.getMemberName());
@@ -236,6 +236,20 @@ class MemberServiceTest {
 		doReturn(Optional.empty()).when(memberRepository).findFirstByMemberId(10);
 
 		// when
-		assertThrows(MemberNotFoundException.class, () -> memberService.findMemberByMemberId(10));
+		assertThrows(MemberNotFoundException.class, () -> memberService.findMemberResponseByMemberId(10));
+	}
+
+	@DisplayName("사용자명으로 사용자 조회")
+	@Test
+	void findMemberByMemberName() {
+		// given
+		Member member = Member.builder().memberId(1).memberName("admin").build();
+		doReturn(Optional.of(member)).when(memberRepository).findFirstByMemberName("admin");
+
+		// when
+		Member result = memberService.findMemberByMemberName("admin");
+
+		// then
+		assertEquals(member.getMemberName(), result.getMemberName());
 	}
 }

--- a/src/test/java/dev/cass/knorda/api/product/controller/ProductControllerTest.java
+++ b/src/test/java/dev/cass/knorda/api/product/controller/ProductControllerTest.java
@@ -31,14 +31,12 @@ import dev.cass.knorda.global.util.SessionManageUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ProductControllerTest {
+	ObjectMapper objectMapper = new ObjectMapper();
 	@InjectMocks
 	private ProductController productController;
-
 	@Mock
 	private ProductFacade productFacade;
-
 	private MockMvc mockMvc;
-	ObjectMapper objectMapper = new ObjectMapper();
 
 	@BeforeEach
 	void setUp() {
@@ -86,7 +84,7 @@ class ProductControllerTest {
 
 		// when
 		ResultActions resultActions = mockMvc.perform(delete("/api/v1/products/{productId}", productId)
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, userId)));
 
 		// then
 		resultActions
@@ -116,7 +114,7 @@ class ProductControllerTest {
 		ResultActions resultActions = mockMvc.perform(put("/api/v1/products/{productId}", productId)
 			.contentType("application/json")
 			.content(objectMapper.writeValueAsString(updateProductRegisterRequest))
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, userId)));
 
 		// then
 		resultActions
@@ -138,7 +136,7 @@ class ProductControllerTest {
 		ResultActions resultActions = mockMvc.perform(put("/api/v1/products/{productId}", productId)
 			.contentType("application/json")
 			.content(objectMapper.writeValueAsString(updateProductRegisterRequest))
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, userId)));
 
 		// then
 		resultActions
@@ -243,7 +241,7 @@ class ProductControllerTest {
 		ResultActions resultActions = mockMvc.perform(post("/api/v1/products")
 			.contentType("application/json")
 			.content(objectMapper.writeValueAsString(registerProductRegisterRequest))
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, userId)));
 
 		// then
 		resultActions
@@ -265,7 +263,7 @@ class ProductControllerTest {
 		ResultActions resultActions = mockMvc.perform(post("/api/v1/products")
 			.contentType("application/json")
 			.content(objectMapper.writeValueAsString(registerProductRegisterRequest))
-			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
+			.sessionAttr(SessionManageUtils.SESSION_MEMBER, new AuthDto.SessionDto(name, userId)));
 
 		// then
 		resultActions

--- a/src/test/java/dev/cass/knorda/api/product/controller/ProductControllerTest.java
+++ b/src/test/java/dev/cass/knorda/api/product/controller/ProductControllerTest.java
@@ -1,0 +1,270 @@
+package dev.cass.knorda.api.product.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import dev.cass.knorda.api.member.dto.AuthDto;
+import dev.cass.knorda.api.product.dto.ProductFindDto;
+import dev.cass.knorda.api.product.dto.ProductRegisterDto;
+import dev.cass.knorda.api.product.facade.ProductFacade;
+import dev.cass.knorda.global.exception1.GlobalExceptionHandler;
+import dev.cass.knorda.global.util.SessionManageUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ProductControllerTest {
+	@InjectMocks
+	private ProductController productController;
+
+	@Mock
+	private ProductFacade productFacade;
+
+	private MockMvc mockMvc;
+	ObjectMapper objectMapper = new ObjectMapper();
+
+	@BeforeEach
+	void setUp() {
+		mockMvc = MockMvcBuilders.standaloneSetup(productController)
+			.setControllerAdvice(GlobalExceptionHandler.class).build();
+
+		/*
+		 * Java 8의 새로운 날짜와 시간 타입인 LocalDateTime, LocalDate, LocalTime 은 Jackson 라이브러리가 기본적으로 직렬화/역직렬화를 지원하지 않음
+		 * 그래서 해당 날짜 타입들을 처리할 수 있는 모듈인 jackon-datatype-jsr310을 implement 해줘야 하고,
+		 * 그 모듈을 objectMapper에서 사용하기 위해 register해줘야 정상적으로 동작한다
+		 */
+		objectMapper.registerModule(new JavaTimeModule());
+	}
+
+	@DisplayName("상품번호로 상품조회")
+	@Test
+	void findById() throws Exception {
+		// given
+		int productId = 1;
+		ProductFindDto.GetProductResponse getProductResponse = new ProductFindDto.GetProductResponse(productId,
+			"Product 1", null, "description", "admin",
+			LocalDateTime.of(2020, 10, 10, 0, 0, 0),
+			LocalDateTime.of(2020, 10, 10, 0, 0, 0));
+
+		doReturn(getProductResponse).when(productFacade).getProductById(productId);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/products/{productId}", productId));
+
+		// then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(getProductResponse)));
+	}
+
+	@DisplayName("상품번호로 상품 삭제")
+	@Test
+	void deleteById() throws Exception {
+		// given
+		int productId = 1;
+		String name = "admin";
+		int userId = 1;
+
+		doNothing().when(productFacade).deleteProduct(productId, name);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/v1/products/{productId}", productId)
+			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
+
+		// then
+		resultActions
+			.andExpect(status().isNoContent());
+		verify(productFacade, times(1)).deleteProduct(productId, name);
+	}
+
+	@DisplayName("상품번호로 수정")
+	@Test
+	void updateById() throws Exception {
+		// given
+		int productId = 1;
+		String name = "admin";
+		int userId = 1;
+		ProductRegisterDto.request updateProductRequest = new ProductRegisterDto.request("Product 1 new",
+			"Product 1 description new");
+		ProductRegisterDto.response getProductResponse = new ProductRegisterDto.response(productId,
+			"Product 1 new", "Product 1 description new",
+			LocalDateTime.of(2020, 10, 10, 0, 0, 0));
+
+		doReturn(getProductResponse).when(productFacade)
+			.updateProduct(eq(productId), any(ProductRegisterDto.request.class), eq(name));
+
+		// when
+		ResultActions resultActions = mockMvc.perform(put("/api/v1/products/{productId}", productId)
+			.contentType("application/json")
+			.content(objectMapper.writeValueAsString(updateProductRequest))
+			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
+
+		// then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(getProductResponse)));
+	}
+
+	@DisplayName("상품번호로 수정 - 이름이 없음")
+	@Test
+	void updateByIdWithoutName() throws Exception {
+		// given
+		int productId = 1;
+		String name = "admin";
+		int userId = 1;
+		ProductRegisterDto.request updateProductRequest = new ProductRegisterDto.request(null,
+			"Product 1 description new");
+
+		// when
+		ResultActions resultActions = mockMvc.perform(put("/api/v1/products/{productId}", productId)
+			.contentType("application/json")
+			.content(objectMapper.writeValueAsString(updateProductRequest))
+			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
+
+		// then
+		resultActions
+			.andExpect(status().isBadRequest());
+	}
+
+	@DisplayName("상품 쿼리 조회")
+	@Test
+	void getProductList() throws Exception {
+		// given
+		ProductFindDto.GetProductQuery productQuery = new ProductFindDto.GetProductQuery("Product 3", "admin", null,
+			null);
+		ProductFindDto.GetProductResponse getProductResponse = new ProductFindDto.GetProductResponse(3,
+			"Product 3", null, "description", "admin",
+			LocalDateTime.of(2020, 10, 10, 0, 0, 0),
+			LocalDateTime.of(2020, 10, 10, 0, 0, 0));
+
+		doReturn(List.of(getProductResponse)).when(productFacade)
+			.getProductListByQuery(any(ProductFindDto.GetProductQuery.class));
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/products")
+			.param("productName", productQuery.getProductName())
+			.param("memberName", productQuery.getMemberName()));
+
+		// then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(content().json(objectMapper.writeValueAsString(List.of(getProductResponse))));
+	}
+
+	@DisplayName("상품 쿼리 조회 - 시작날짜가 없음")
+	@Test
+	void getProductListWithoutStartDate() throws Exception {
+		// given
+		String productName = "Product 3";
+		String memberName = "admin";
+		String startDateTime = LocalDateTime.of(2020, 10, 10, 0, 0, 0)
+			.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/products")
+			.param("productName", productName)
+			.param("memberName", memberName)
+			.param("startDateTime", startDateTime));
+
+		// then
+		resultActions
+			.andExpect(status().isBadRequest());
+	}
+
+	@DisplayName("상품 쿼리 조회 - 시작 날짜가 끝 날짜보다 뒤임")
+	@Test
+	void getProductListStartDateAfterEndDate() throws Exception {
+		// given
+		String productName = "Product 3";
+		String memberName = "admin";
+		String startDateTime = LocalDateTime.of(2020, 10, 10, 0, 0, 0)
+			.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+		String endDateTime = LocalDateTime.of(2019, 10, 10, 0, 0, 0)
+			.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/products")
+			.param("productName", productName)
+			.param("memberName", memberName)
+			.param("startDateTime", startDateTime)
+			.param("endDateTime", endDateTime));
+
+		// then
+		resultActions
+			.andExpect(status().isBadRequest());
+	}
+
+	@DisplayName("상품 쿼리 조회 - 모든 값이 없음")
+	@Test
+	void getProductListWithoutAll() throws Exception {
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/products"));
+
+		// then
+		resultActions
+			.andExpect(status().isBadRequest());
+	}
+
+	@DisplayName("상품 등록")
+	@Test
+	void registerProduct() throws Exception {
+		// given
+		String name = "admin";
+		int userId = 1;
+		ProductRegisterDto.request registerProductRequest = new ProductRegisterDto.request("Product 1",
+			"Product 1 description");
+
+		ProductRegisterDto.response getProductResponse = new ProductRegisterDto.response(1,
+			"Product 1", "Product 1 description",
+			LocalDateTime.of(2020, 10, 10, 0, 0, 0));
+
+		doReturn(getProductResponse).when(productFacade)
+			.registerProduct(any(ProductRegisterDto.request.class), eq(name));
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/v1/products")
+			.contentType("application/json")
+			.content(objectMapper.writeValueAsString(registerProductRequest))
+			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
+
+		// then
+		resultActions
+			.andExpect(status().isCreated())
+			.andExpect(content().json(objectMapper.writeValueAsString(getProductResponse)));
+	}
+
+	@DisplayName("상품 등록 Validation 실패")
+	@Test
+	void registerProductNotValid() throws Exception {
+		// given
+		String name = "admin";
+		int userId = 1;
+		ProductRegisterDto.request registerProductRequest = new ProductRegisterDto.request("Product 1",
+			null);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/v1/products")
+			.contentType("application/json")
+			.content(objectMapper.writeValueAsString(registerProductRequest))
+			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
+
+		// then
+		resultActions
+			.andExpect(status().isBadRequest());
+	}
+}

--- a/src/test/java/dev/cass/knorda/api/product/controller/ProductControllerTest.java
+++ b/src/test/java/dev/cass/knorda/api/product/controller/ProductControllerTest.java
@@ -101,25 +101,27 @@ class ProductControllerTest {
 		int productId = 1;
 		String name = "admin";
 		int userId = 1;
-		ProductRegisterDto.request updateProductRequest = new ProductRegisterDto.request("Product 1 new",
+		ProductRegisterDto.RegisterRequest updateProductRegisterRequest = new ProductRegisterDto.RegisterRequest(
+			"Product 1 new",
 			"Product 1 description new");
-		ProductRegisterDto.response getProductResponse = new ProductRegisterDto.response(productId,
+		ProductRegisterDto.RegisterResponse getProductRegisterResponse = new ProductRegisterDto.RegisterResponse(
+			productId,
 			"Product 1 new", "Product 1 description new",
 			LocalDateTime.of(2020, 10, 10, 0, 0, 0));
 
-		doReturn(getProductResponse).when(productFacade)
-			.updateProduct(eq(productId), any(ProductRegisterDto.request.class), eq(name));
+		doReturn(getProductRegisterResponse).when(productFacade)
+			.updateProduct(eq(productId), any(ProductRegisterDto.RegisterRequest.class), eq(name));
 
 		// when
 		ResultActions resultActions = mockMvc.perform(put("/api/v1/products/{productId}", productId)
 			.contentType("application/json")
-			.content(objectMapper.writeValueAsString(updateProductRequest))
+			.content(objectMapper.writeValueAsString(updateProductRegisterRequest))
 			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
 
 		// then
 		resultActions
 			.andExpect(status().isOk())
-			.andExpect(content().json(objectMapper.writeValueAsString(getProductResponse)));
+			.andExpect(content().json(objectMapper.writeValueAsString(getProductRegisterResponse)));
 	}
 
 	@DisplayName("상품번호로 수정 - 이름이 없음")
@@ -129,13 +131,13 @@ class ProductControllerTest {
 		int productId = 1;
 		String name = "admin";
 		int userId = 1;
-		ProductRegisterDto.request updateProductRequest = new ProductRegisterDto.request(null,
+		ProductRegisterDto.RegisterRequest updateProductRegisterRequest = new ProductRegisterDto.RegisterRequest(null,
 			"Product 1 description new");
 
 		// when
 		ResultActions resultActions = mockMvc.perform(put("/api/v1/products/{productId}", productId)
 			.contentType("application/json")
-			.content(objectMapper.writeValueAsString(updateProductRequest))
+			.content(objectMapper.writeValueAsString(updateProductRegisterRequest))
 			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
 
 		// then
@@ -226,26 +228,27 @@ class ProductControllerTest {
 		// given
 		String name = "admin";
 		int userId = 1;
-		ProductRegisterDto.request registerProductRequest = new ProductRegisterDto.request("Product 1",
+		ProductRegisterDto.RegisterRequest registerProductRegisterRequest = new ProductRegisterDto.RegisterRequest(
+			"Product 1",
 			"Product 1 description");
 
-		ProductRegisterDto.response getProductResponse = new ProductRegisterDto.response(1,
+		ProductRegisterDto.RegisterResponse getProductRegisterResponse = new ProductRegisterDto.RegisterResponse(1,
 			"Product 1", "Product 1 description",
 			LocalDateTime.of(2020, 10, 10, 0, 0, 0));
 
-		doReturn(getProductResponse).when(productFacade)
-			.registerProduct(any(ProductRegisterDto.request.class), eq(name));
+		doReturn(getProductRegisterResponse).when(productFacade)
+			.registerProduct(any(ProductRegisterDto.RegisterRequest.class), eq(name));
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/v1/products")
 			.contentType("application/json")
-			.content(objectMapper.writeValueAsString(registerProductRequest))
+			.content(objectMapper.writeValueAsString(registerProductRegisterRequest))
 			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
 
 		// then
 		resultActions
 			.andExpect(status().isCreated())
-			.andExpect(content().json(objectMapper.writeValueAsString(getProductResponse)));
+			.andExpect(content().json(objectMapper.writeValueAsString(getProductRegisterResponse)));
 	}
 
 	@DisplayName("상품 등록 Validation 실패")
@@ -254,13 +257,14 @@ class ProductControllerTest {
 		// given
 		String name = "admin";
 		int userId = 1;
-		ProductRegisterDto.request registerProductRequest = new ProductRegisterDto.request("Product 1",
+		ProductRegisterDto.RegisterRequest registerProductRegisterRequest = new ProductRegisterDto.RegisterRequest(
+			"Product 1",
 			null);
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/v1/products")
 			.contentType("application/json")
-			.content(objectMapper.writeValueAsString(registerProductRequest))
+			.content(objectMapper.writeValueAsString(registerProductRegisterRequest))
 			.sessionAttr(SessionManageUtils.SESSION_USER, new AuthDto.SessionDto(name, userId)));
 
 		// then

--- a/src/test/java/dev/cass/knorda/api/product/facade/ProductFacadeTest.java
+++ b/src/test/java/dev/cass/knorda/api/product/facade/ProductFacadeTest.java
@@ -17,7 +17,7 @@ import dev.cass.knorda.api.member.service.MemberService;
 import dev.cass.knorda.api.product.dto.ProductFindDto;
 import dev.cass.knorda.api.product.dto.ProductRegisterDto;
 import dev.cass.knorda.api.product.exception.AlreadyExistProductNameException;
-import dev.cass.knorda.api.product.exception.NotYourProductException;
+import dev.cass.knorda.api.product.exception.ProductNotOwnedByLoggedInMemberException;
 import dev.cass.knorda.api.product.service.ProductService;
 import dev.cass.knorda.domain.member.Member;
 import dev.cass.knorda.domain.product.Product;
@@ -97,7 +97,7 @@ class ProductFacadeTest {
 
 		doReturn(member).when(memberService).findMemberByMemberName(memberName);
 		doReturn(false).when(productService).isExistProductName(registerRequest.getProductName());
-		doReturn(product).when(productService).save(registerRequest, member);
+		doReturn(product).when(productService).save(any(Product.class));
 
 		// when
 		ProductRegisterDto.RegisterResponse productRegisterResponse = productFacade.registerProduct(registerRequest,
@@ -184,7 +184,8 @@ class ProductFacadeTest {
 		doReturn(product).when(productService).findById(productId);
 
 		// when
-		assertThrows(NotYourProductException.class, () -> productFacade.deleteProduct(productId, "user"));
+		assertThrows(ProductNotOwnedByLoggedInMemberException.class,
+			() -> productFacade.deleteProduct(productId, "user"));
 
 		// then
 		verify(productService, never()).delete(product);
@@ -249,7 +250,7 @@ class ProductFacadeTest {
 		doReturn(product).when(productService).findById(productId);
 
 		// when
-		assertThrows(NotYourProductException.class,
+		assertThrows(ProductNotOwnedByLoggedInMemberException.class,
 			() -> productFacade.updateProduct(productId, updateRegisterRequest, "user"));
 
 		// then

--- a/src/test/java/dev/cass/knorda/api/product/facade/ProductFacadeTest.java
+++ b/src/test/java/dev/cass/knorda/api/product/facade/ProductFacadeTest.java
@@ -67,7 +67,7 @@ class ProductFacadeTest {
 	void registerProductDuplicateName() {
 		// given
 		String memberName = "admin";
-		ProductRegisterDto.request registerRequest = new ProductRegisterDto.request("Product 1",
+		ProductRegisterDto.RegisterRequest registerRequest = new ProductRegisterDto.RegisterRequest("Product 1",
 			"Product 1 description");
 
 		doReturn(true).when(productService).isExistProductName(registerRequest.getProductName());
@@ -87,7 +87,7 @@ class ProductFacadeTest {
 			.memberName(memberName)
 			.password("admin")
 			.build();
-		ProductRegisterDto.request registerRequest = new ProductRegisterDto.request("Product 1",
+		ProductRegisterDto.RegisterRequest registerRequest = new ProductRegisterDto.RegisterRequest("Product 1",
 			"Product 1 description");
 		Product product = Product.builder()
 			.productId(1)
@@ -100,11 +100,12 @@ class ProductFacadeTest {
 		doReturn(product).when(productService).save(registerRequest, member);
 
 		// when
-		ProductRegisterDto.response productResponse = productFacade.registerProduct(registerRequest, memberName);
+		ProductRegisterDto.RegisterResponse productRegisterResponse = productFacade.registerProduct(registerRequest,
+			memberName);
 
 		// then
-		assertEquals(productResponse.getProductName(), product.getName());
-		assertEquals(productResponse.getDescription(), product.getDescription());
+		assertEquals(productRegisterResponse.getProductName(), product.getName());
+		assertEquals(productRegisterResponse.getDescription(), product.getDescription());
 	}
 
 	@DisplayName("상품 조회 - 쿼리")
@@ -200,7 +201,8 @@ class ProductFacadeTest {
 			.memberName(memberName)
 			.password("admin")
 			.build();
-		ProductRegisterDto.request updateRequest = new ProductRegisterDto.request("Product 1 new",
+		ProductRegisterDto.RegisterRequest updateRegisterRequest = new ProductRegisterDto.RegisterRequest(
+			"Product 1 new",
 			"Product 1 description new");
 		Product product = Product.builder()
 			.productId(productId)
@@ -211,16 +213,17 @@ class ProductFacadeTest {
 
 		doReturn(product).when(productService).findById(productId);
 
-		product.update(updateRequest.getProductName(), updateRequest.getDescription());
+		product.update(updateRegisterRequest.getProductName(), updateRegisterRequest.getDescription());
 
-		doReturn(product).when(productService).update(product, updateRequest);
+		doReturn(product).when(productService).update(product, updateRegisterRequest);
 
 		// when
-		ProductRegisterDto.response productResponse = productFacade.updateProduct(productId, updateRequest, memberName);
+		ProductRegisterDto.RegisterResponse productRegisterResponse = productFacade.updateProduct(productId,
+			updateRegisterRequest, memberName);
 
 		// then
-		assertEquals(productResponse.getProductName(), product.getName());
-		assertEquals(productResponse.getDescription(), product.getDescription());
+		assertEquals(productRegisterResponse.getProductName(), product.getName());
+		assertEquals(productRegisterResponse.getDescription(), product.getDescription());
 	}
 
 	@DisplayName("상품 수정 - 다른 사용자")
@@ -233,7 +236,8 @@ class ProductFacadeTest {
 			.memberName("admin")
 			.password("admin")
 			.build();
-		ProductRegisterDto.request updateRequest = new ProductRegisterDto.request("Product 1 new",
+		ProductRegisterDto.RegisterRequest updateRegisterRequest = new ProductRegisterDto.RegisterRequest(
+			"Product 1 new",
 			"Product 1 description new");
 		Product product = Product.builder()
 			.productId(productId)
@@ -246,10 +250,10 @@ class ProductFacadeTest {
 
 		// when
 		assertThrows(NotYourProductException.class,
-			() -> productFacade.updateProduct(productId, updateRequest, "user"));
+			() -> productFacade.updateProduct(productId, updateRegisterRequest, "user"));
 
 		// then
-		verify(productService, never()).update(product, updateRequest);
+		verify(productService, never()).update(product, updateRegisterRequest);
 	}
 
 	@DisplayName("상품 수정 - 이름 중복")
@@ -263,7 +267,8 @@ class ProductFacadeTest {
 			.memberName(memberName)
 			.password("admin")
 			.build();
-		ProductRegisterDto.request updateRequest = new ProductRegisterDto.request("Product 1 new",
+		ProductRegisterDto.RegisterRequest updateRegisterRequest = new ProductRegisterDto.RegisterRequest(
+			"Product 1 new",
 			"Product 1 description new");
 		Product product = Product.builder()
 			.productId(productId)
@@ -273,14 +278,14 @@ class ProductFacadeTest {
 			.build();
 
 		doReturn(product).when(productService).findById(productId);
-		doReturn(true).when(productService).isExistProductName(updateRequest.getProductName());
+		doReturn(true).when(productService).isExistProductName(updateRegisterRequest.getProductName());
 
 		// when
 		assertThrows(AlreadyExistProductNameException.class,
-			() -> productFacade.updateProduct(productId, updateRequest, memberName));
+			() -> productFacade.updateProduct(productId, updateRegisterRequest, memberName));
 
 		// then
-		verify(productService, never()).update(product, updateRequest);
+		verify(productService, never()).update(product, updateRegisterRequest);
 	}
 
 	@DisplayName("상품 수정 - 현재 상품명과 동일")
@@ -294,7 +299,7 @@ class ProductFacadeTest {
 			.memberName(memberName)
 			.password("admin")
 			.build();
-		ProductRegisterDto.request updateRequest = new ProductRegisterDto.request("Product 1",
+		ProductRegisterDto.RegisterRequest updateRegisterRequest = new ProductRegisterDto.RegisterRequest("Product 1",
 			"Product 1 description");
 		Product product = Product.builder()
 			.productId(productId)
@@ -305,15 +310,16 @@ class ProductFacadeTest {
 
 		doReturn(product).when(productService).findById(productId);
 
-		product.update(updateRequest.getProductName(), updateRequest.getDescription());
+		product.update(updateRegisterRequest.getProductName(), updateRegisterRequest.getDescription());
 
-		doReturn(product).when(productService).update(product, updateRequest);
+		doReturn(product).when(productService).update(product, updateRegisterRequest);
 
 		// when
-		ProductRegisterDto.response productResponse = productFacade.updateProduct(productId, updateRequest, memberName);
+		ProductRegisterDto.RegisterResponse productRegisterResponse = productFacade.updateProduct(productId,
+			updateRegisterRequest, memberName);
 
 		// then
-		assertEquals(productResponse.getProductName(), product.getName());
-		assertEquals(productResponse.getDescription(), product.getDescription());
+		assertEquals(productRegisterResponse.getProductName(), product.getName());
+		assertEquals(productRegisterResponse.getDescription(), product.getDescription());
 	}
 }

--- a/src/test/java/dev/cass/knorda/api/product/facade/ProductFacadeTest.java
+++ b/src/test/java/dev/cass/knorda/api/product/facade/ProductFacadeTest.java
@@ -1,0 +1,319 @@
+package dev.cass.knorda.api.product.facade;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import dev.cass.knorda.api.member.service.MemberService;
+import dev.cass.knorda.api.product.dto.ProductFindDto;
+import dev.cass.knorda.api.product.dto.ProductRegisterDto;
+import dev.cass.knorda.api.product.exception.AlreadyExistProductNameException;
+import dev.cass.knorda.api.product.exception.NotYourProductException;
+import dev.cass.knorda.api.product.service.ProductService;
+import dev.cass.knorda.domain.member.Member;
+import dev.cass.knorda.domain.product.Product;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class ProductFacadeTest {
+	@InjectMocks
+	private ProductFacade productFacade;
+
+	@Mock
+	private ProductService productService;
+
+	@Mock
+	private MemberService memberService;
+
+	@DisplayName("상품번호로 상품 조회")
+	@Test
+	void findById() {
+		// given
+		int productId = 1;
+		Member member = Member.builder()
+			.memberId(1)
+			.memberName("admin")
+			.password("admin")
+			.build();
+		Product product = Product.builder()
+			.productId(1)
+			.name("Product 1")
+			.description("Product 1 description")
+			.member(member)
+			.build();
+
+		doReturn(product).when(productService).findById(productId);
+
+		// when
+		ProductFindDto.GetProductResponse productResponse = productFacade.getProductById(productId);
+
+		// then
+		assertEquals(productResponse.getName(), product.getName());
+		assertEquals(productResponse.getDescription(), product.getDescription());
+		assertEquals(productResponse.getRegisterMemberName(), product.getMember().getMemberName());
+	}
+
+	@DisplayName("상품 등록 - 이름 중복")
+	@Test
+	void registerProductDuplicateName() {
+		// given
+		String memberName = "admin";
+		ProductRegisterDto.request registerRequest = new ProductRegisterDto.request("Product 1",
+			"Product 1 description");
+
+		doReturn(true).when(productService).isExistProductName(registerRequest.getProductName());
+
+		// when
+		assertThrows(
+			AlreadyExistProductNameException.class, () -> productFacade.registerProduct(registerRequest, memberName));
+	}
+
+	@DisplayName("상품 등록")
+	@Test
+	void registerProduct() {
+		// given
+		String memberName = "admin";
+		Member member = Member.builder()
+			.memberId(1)
+			.memberName(memberName)
+			.password("admin")
+			.build();
+		ProductRegisterDto.request registerRequest = new ProductRegisterDto.request("Product 1",
+			"Product 1 description");
+		Product product = Product.builder()
+			.productId(1)
+			.name(registerRequest.getProductName())
+			.description(registerRequest.getDescription())
+			.build();
+
+		doReturn(member).when(memberService).findMemberByMemberName(memberName);
+		doReturn(false).when(productService).isExistProductName(registerRequest.getProductName());
+		doReturn(product).when(productService).save(registerRequest, member);
+
+		// when
+		ProductRegisterDto.response productResponse = productFacade.registerProduct(registerRequest, memberName);
+
+		// then
+		assertEquals(productResponse.getProductName(), product.getName());
+		assertEquals(productResponse.getDescription(), product.getDescription());
+	}
+
+	@DisplayName("상품 조회 - 쿼리")
+	@Test
+	void getProductsByQuery() {
+		// given
+		ProductFindDto.GetProductQuery productQuery = new ProductFindDto.GetProductQuery("Product 3", null, null, null);
+		Member member = Member.builder()
+			.memberId(1)
+			.memberName("admin")
+			.password("admin")
+			.build();
+		Product product = Product.builder()
+			.productId(3)
+			.name("Product 3")
+			.description("Product 3 description")
+			.member(member)
+			.build();
+
+		doReturn(List.of(product)).when(productService).findAllByQuery(productQuery);
+
+		// when
+		List<ProductFindDto.GetProductResponse> productResponse = productFacade.getProductListByQuery(productQuery);
+
+		// then
+		assertEquals(1, productResponse.size());
+		assertEquals(product.getName(), productResponse.getFirst().getName());
+		assertEquals(product.getDescription(), productResponse.getFirst().getDescription());
+	}
+
+	@DisplayName("상품 삭제")
+	@Test
+	void deleteProduct() {
+		// given
+		int productId = 1;
+		String memberName = "admin";
+		Member member = Member.builder()
+			.memberId(1)
+			.memberName(memberName)
+			.password("admin")
+			.build();
+		Product product = Product.builder()
+			.productId(productId)
+			.name("Product 1")
+			.description("Product 1 description")
+			.member(member)
+			.build();
+
+		doReturn(product).when(productService).findById(productId);
+		doNothing().when(productService).delete(product);
+
+		// when
+		productFacade.deleteProduct(productId, memberName);
+
+		// then
+		verify(productService).delete(product);
+	}
+
+	@DisplayName("상품 삭제 - 다른 사용자")
+	@Test
+	void deleteProductDifferentMember() {
+		// given
+		int productId = 1;
+		Member member = Member.builder()
+			.memberId(1)
+			.memberName("admin")
+			.password("admin")
+			.build();
+		Product product = Product.builder()
+			.productId(productId)
+			.name("Product 1")
+			.description("Product 1 description")
+			.member(member)
+			.build();
+
+		doReturn(product).when(productService).findById(productId);
+
+		// when
+		assertThrows(NotYourProductException.class, () -> productFacade.deleteProduct(productId, "user"));
+
+		// then
+		verify(productService, never()).delete(product);
+	}
+
+	@DisplayName("상품 수정")
+	@Test
+	void updateProduct() {
+		// given
+		int productId = 1;
+		String memberName = "admin";
+		Member member = Member.builder()
+			.memberId(1)
+			.memberName(memberName)
+			.password("admin")
+			.build();
+		ProductRegisterDto.request updateRequest = new ProductRegisterDto.request("Product 1 new",
+			"Product 1 description new");
+		Product product = Product.builder()
+			.productId(productId)
+			.name("Product 1")
+			.description("Product 1 description")
+			.member(member)
+			.build();
+
+		doReturn(product).when(productService).findById(productId);
+
+		product.update(updateRequest.getProductName(), updateRequest.getDescription());
+
+		doReturn(product).when(productService).update(product, updateRequest);
+
+		// when
+		ProductRegisterDto.response productResponse = productFacade.updateProduct(productId, updateRequest, memberName);
+
+		// then
+		assertEquals(productResponse.getProductName(), product.getName());
+		assertEquals(productResponse.getDescription(), product.getDescription());
+	}
+
+	@DisplayName("상품 수정 - 다른 사용자")
+	@Test
+	void updateProductDifferentMember() {
+		// given
+		int productId = 1;
+		Member member = Member.builder()
+			.memberId(1)
+			.memberName("admin")
+			.password("admin")
+			.build();
+		ProductRegisterDto.request updateRequest = new ProductRegisterDto.request("Product 1 new",
+			"Product 1 description new");
+		Product product = Product.builder()
+			.productId(productId)
+			.name("Product 1")
+			.description("Product 1 description")
+			.member(member)
+			.build();
+
+		doReturn(product).when(productService).findById(productId);
+
+		// when
+		assertThrows(NotYourProductException.class,
+			() -> productFacade.updateProduct(productId, updateRequest, "user"));
+
+		// then
+		verify(productService, never()).update(product, updateRequest);
+	}
+
+	@DisplayName("상품 수정 - 이름 중복")
+	@Test
+	void updateProductDuplicateName() {
+		// given
+		int productId = 1;
+		String memberName = "admin";
+		Member member = Member.builder()
+			.memberId(1)
+			.memberName(memberName)
+			.password("admin")
+			.build();
+		ProductRegisterDto.request updateRequest = new ProductRegisterDto.request("Product 1 new",
+			"Product 1 description new");
+		Product product = Product.builder()
+			.productId(productId)
+			.name("Product 1")
+			.description("Product 1 description")
+			.member(member)
+			.build();
+
+		doReturn(product).when(productService).findById(productId);
+		doReturn(true).when(productService).isExistProductName(updateRequest.getProductName());
+
+		// when
+		assertThrows(AlreadyExistProductNameException.class,
+			() -> productFacade.updateProduct(productId, updateRequest, memberName));
+
+		// then
+		verify(productService, never()).update(product, updateRequest);
+	}
+
+	@DisplayName("상품 수정 - 현재 상품명과 동일")
+	@Test
+	void updateProductSameName() {
+		// given
+		int productId = 1;
+		String memberName = "admin";
+		Member member = Member.builder()
+			.memberId(1)
+			.memberName(memberName)
+			.password("admin")
+			.build();
+		ProductRegisterDto.request updateRequest = new ProductRegisterDto.request("Product 1",
+			"Product 1 description");
+		Product product = Product.builder()
+			.productId(productId)
+			.name("Product 1")
+			.description("Product 1 description")
+			.member(member)
+			.build();
+
+		doReturn(product).when(productService).findById(productId);
+
+		product.update(updateRequest.getProductName(), updateRequest.getDescription());
+
+		doReturn(product).when(productService).update(product, updateRequest);
+
+		// when
+		ProductRegisterDto.response productResponse = productFacade.updateProduct(productId, updateRequest, memberName);
+
+		// then
+		assertEquals(productResponse.getProductName(), product.getName());
+		assertEquals(productResponse.getDescription(), product.getDescription());
+	}
+}

--- a/src/test/java/dev/cass/knorda/api/product/facade/ProductFacadeTest.java
+++ b/src/test/java/dev/cass/knorda/api/product/facade/ProductFacadeTest.java
@@ -125,7 +125,7 @@ class ProductFacadeTest {
 			.member(member)
 			.build();
 
-		doReturn(List.of(product)).when(productService).findAllByQuery(productQuery);
+		doReturn(List.of(product)).when(productService).findAllByQuery(any());
 
 		// when
 		List<ProductFindDto.GetProductResponse> productResponse = productFacade.getProductListByQuery(productQuery);
@@ -216,7 +216,7 @@ class ProductFacadeTest {
 
 		product.update(updateRegisterRequest.getProductName(), updateRegisterRequest.getDescription());
 
-		doReturn(product).when(productService).update(product, updateRegisterRequest);
+		doReturn(product).when(productService).save(product);
 
 		// when
 		ProductRegisterDto.RegisterResponse productRegisterResponse = productFacade.updateProduct(productId,
@@ -254,7 +254,7 @@ class ProductFacadeTest {
 			() -> productFacade.updateProduct(productId, updateRegisterRequest, "user"));
 
 		// then
-		verify(productService, never()).update(product, updateRegisterRequest);
+		verify(productService, never()).save(product);
 	}
 
 	@DisplayName("상품 수정 - 이름 중복")
@@ -286,7 +286,7 @@ class ProductFacadeTest {
 			() -> productFacade.updateProduct(productId, updateRegisterRequest, memberName));
 
 		// then
-		verify(productService, never()).update(product, updateRegisterRequest);
+		verify(productService, never()).save(product);
 	}
 
 	@DisplayName("상품 수정 - 현재 상품명과 동일")
@@ -313,7 +313,7 @@ class ProductFacadeTest {
 
 		product.update(updateRegisterRequest.getProductName(), updateRegisterRequest.getDescription());
 
-		doReturn(product).when(productService).update(product, updateRegisterRequest);
+		doReturn(product).when(productService).save(product);
 
 		// when
 		ProductRegisterDto.RegisterResponse productRegisterResponse = productFacade.updateProduct(productId,

--- a/src/test/java/dev/cass/knorda/api/product/service/ProductServiceTest.java
+++ b/src/test/java/dev/cass/knorda/api/product/service/ProductServiceTest.java
@@ -61,7 +61,8 @@ class ProductServiceTest {
 	@Test
 	void save() {
 		// given
-		ProductRegisterDto.request productQuery = new ProductRegisterDto.request("Product 1", "Product 1 description");
+		ProductRegisterDto.RegisterRequest productQuery = new ProductRegisterDto.RegisterRequest("Product 1",
+			"Product 1 description");
 		Product product = Product.builder()
 			.productId(1)
 			.name("Product 1")
@@ -88,7 +89,7 @@ class ProductServiceTest {
 	@Test
 	void update() {
 		// given
-		ProductRegisterDto.request productQuery = new ProductRegisterDto.request("Product 1 new",
+		ProductRegisterDto.RegisterRequest productQuery = new ProductRegisterDto.RegisterRequest("Product 1 new",
 			"Product 1 description new");
 		Product product = Product.builder()
 			.productId(1)

--- a/src/test/java/dev/cass/knorda/api/product/service/ProductServiceTest.java
+++ b/src/test/java/dev/cass/knorda/api/product/service/ProductServiceTest.java
@@ -76,10 +76,13 @@ class ProductServiceTest {
 
 		product.setMember(member);
 
+		Product resultProduct = productQuery.toEntity();
+		resultProduct.setMember(member);
+
 		doReturn(product).when(productRepository).saveAndFlush(any(Product.class));
 
 		// when
-		Product product1 = productService.save(productQuery, member);
+		Product product1 = productService.save(resultProduct);
 
 		// then
 		assertEquals(product1.getName(), product.getName());

--- a/src/test/java/dev/cass/knorda/api/product/service/ProductServiceTest.java
+++ b/src/test/java/dev/cass/knorda/api/product/service/ProductServiceTest.java
@@ -1,0 +1,152 @@
+package dev.cass.knorda.api.product.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import dev.cass.knorda.api.product.dto.ProductRegisterDto;
+import dev.cass.knorda.api.product.exception.ProductNotExistException;
+import dev.cass.knorda.domain.member.Member;
+import dev.cass.knorda.domain.product.Product;
+import dev.cass.knorda.domain.product.ProductRepository;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+class ProductServiceTest {
+	@InjectMocks
+	private ProductService productService;
+
+	@Mock
+	private ProductRepository productRepository;
+
+	@DisplayName("ID로 상품 조회")
+	@Test
+	void findById() {
+		// given
+		Product product = Product.builder()
+			.productId(1)
+			.name("Product 1")
+			.description("Product 1 description")
+			.build();
+
+		doReturn(Optional.of(product)).when(productRepository).findFirstByProductId(1);
+
+		// when
+		Product product1 = productService.findById(1);
+
+		// then
+		assertEquals(product1.getName(), product.getName());
+	}
+
+	@DisplayName("ID로 상품 조회 - 상품 없음")
+	@Test
+	void findByIdNotFound() {
+		// given
+		doReturn(Optional.empty()).when(productRepository).findFirstByProductId(1);
+
+		// when
+		assertThrows(ProductNotExistException.class, () -> productService.findById(1));
+	}
+
+	@DisplayName("상품 저장")
+	@Test
+	void save() {
+		// given
+		ProductRegisterDto.request productQuery = new ProductRegisterDto.request("Product 1", "Product 1 description");
+		Product product = Product.builder()
+			.productId(1)
+			.name("Product 1")
+			.description("Product 1 description")
+			.build();
+
+		Member member = Member.builder()
+			.memberId(1)
+			.memberName("admin")
+			.build();
+
+		product.setMember(member);
+
+		doReturn(product).when(productRepository).save(any(Product.class));
+
+		// when
+		Product product1 = productService.save(productQuery, member);
+
+		// then
+		assertEquals(product1.getName(), product.getName());
+	}
+
+	@DisplayName("상품 수정")
+	@Test
+	void update() {
+		// given
+		ProductRegisterDto.request productQuery = new ProductRegisterDto.request("Product 1 new",
+			"Product 1 description new");
+		Product product = Product.builder()
+			.productId(1)
+			.name("Product 1")
+			.description("Product 1 description")
+			.build();
+
+		product.update(productQuery.getProductName(), productQuery.getDescription());
+
+		doReturn(product).when(productRepository).save(product);
+
+		// when
+		Product product1 = productService.update(product, productQuery);
+
+		// then
+		assertEquals(product1.getName(), productQuery.getProductName());
+	}
+
+	@DisplayName("상품 삭제")
+	@Test
+	void delete() {
+		// given
+		Product product = Product.builder()
+			.productId(1)
+			.name("Product 1")
+			.description("Product 1 description")
+			.build();
+
+		product.delete();
+
+		doReturn(product).when(productRepository).save(product);
+
+		// when
+		productService.delete(product);
+
+		// then
+		verify(productRepository, times(1)).save(product);
+		doReturn(Optional.empty()).when(productRepository).findFirstByProductId(1);
+		assertThrows(ProductNotExistException.class, () -> productService.findById(1));
+	}
+
+	@DisplayName("상품 이름 중복 확인")
+	@Test
+	void isExistProductName() {
+		// given
+		String productName = "Product 1";
+		Product product = Product.builder()
+			.productId(1)
+			.name("Product 1")
+			.description("Product 1 description")
+			.build();
+
+		doReturn(Optional.of(product)).when(productRepository).findFirstByNameAndIsDeletedFalse(productName);
+
+		// when
+		boolean isExist = productService.isExistProductName(productName);
+
+		// then
+		assertTrue(isExist);
+	}
+}

--- a/src/test/java/dev/cass/knorda/api/product/service/ProductServiceTest.java
+++ b/src/test/java/dev/cass/knorda/api/product/service/ProductServiceTest.java
@@ -76,7 +76,7 @@ class ProductServiceTest {
 
 		product.setMember(member);
 
-		doReturn(product).when(productRepository).save(any(Product.class));
+		doReturn(product).when(productRepository).saveAndFlush(any(Product.class));
 
 		// when
 		Product product1 = productService.save(productQuery, member);
@@ -99,7 +99,7 @@ class ProductServiceTest {
 
 		product.update(productQuery.getProductName(), productQuery.getDescription());
 
-		doReturn(product).when(productRepository).save(product);
+		doReturn(product).when(productRepository).saveAndFlush(product);
 
 		// when
 		Product product1 = productService.update(product, productQuery);
@@ -136,13 +136,8 @@ class ProductServiceTest {
 	void isExistProductName() {
 		// given
 		String productName = "Product 1";
-		Product product = Product.builder()
-			.productId(1)
-			.name("Product 1")
-			.description("Product 1 description")
-			.build();
 
-		doReturn(Optional.of(product)).when(productRepository).findFirstByNameAndIsDeletedFalse(productName);
+		doReturn(true).when(productRepository).existsByName(productName);
 
 		// when
 		boolean isExist = productService.isExistProductName(productName);

--- a/src/test/java/dev/cass/knorda/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/dev/cass/knorda/domain/product/ProductRepositoryTest.java
@@ -103,16 +103,16 @@ class ProductRepositoryTest {
 		assertFalse(product.isEmpty());
 	}
 
-	@DisplayName("상품 이름으로 상품 조회")
+	@DisplayName("상품 이름으로 상품 존재 여부 확인")
 	@Test
 	void findByName() {
 		// given
 		String name = "Product 1";
 
 		// when
-		Product product = productRepository.findFirstByNameAndIsDeletedFalse(name).orElse(null);
+		boolean product = productRepository.existsByName(name);
 
 		// then
-		assertNotNull(product);
+		assertTrue(product);
 	}
 }

--- a/src/test/java/dev/cass/knorda/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/dev/cass/knorda/domain/product/ProductRepositoryTest.java
@@ -1,0 +1,118 @@
+package dev.cass.knorda.domain.product;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import dev.cass.knorda.api.product.dto.ProductFindDto;
+import dev.cass.knorda.api.product.service.ProductService;
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProductRepositoryTest {
+	@Autowired
+	private ProductRepository productRepository;
+
+	@Autowired
+	private ProductService productService;
+
+	/**
+	 * 동적 쿼리 테스트를 해야 하는데, mocking하다 보면 data.sql에 있는 데이터를 가져오지 못한다.
+	 * 그러면 beforeEach에서 데이터를 넣어주는 방법이 있지만, 그렇게 되면 테스트 코드가 너무 길어진다.
+	 * 그래서 일단 repositoryTest 클래스에서 테스트를 진행시켰는데, productServiceTest 클래스를 두 개를 작성해야 할지?
+	 * 동적 쿼리 부분을 따로 Repository 클래스로 분리하려고 해도, specification은 JpaSpecificationExecutor 인터페이스의 메소드를 호출해야 되기 때문에 순환참조가 일어날 것 같음?
+	 * 우선 동적 쿼리에 대한 테스트는 임시로 repositoryTest에 작성하고, 어떻게 변경할지 정할 예정
+	 */
+	@DisplayName("동적 쿼리 - 회원으로 상품 조회")
+	@Test
+	void findAllByQueryMemberName() {
+		// given
+		ProductFindDto.GetProductQuery productQuery = new ProductFindDto.GetProductQuery(null, "admin", null, null);
+
+		// when
+		List<Product> products = productService.findAllByQuery(productQuery);
+
+		// then
+		assertEquals(2, products.size());
+	}
+
+	@DisplayName("동적 쿼리 - 상품명으로 상품 조회")
+	@Test
+	void findAllByQueryProductName() {
+		// given
+		ProductFindDto.GetProductQuery productQuery = new ProductFindDto.GetProductQuery("Product 3", null, null, null);
+
+		// when
+		List<Product> products = productService.findAllByQuery(productQuery);
+
+		// then
+		assertEquals(1, products.size());
+	}
+
+	@DisplayName("동적 쿼리 - 날짜로 상품 조회")
+	@Test
+	void findAllByQueryStartDateAndEndDate() {
+		// given
+		ProductFindDto.GetProductQuery productQuery = new ProductFindDto.GetProductQuery(null, null,
+			LocalDateTime.of(2020, 10, 10, 0, 0, 0),
+			LocalDateTime.of(2021, 10, 10, 0, 0, 0));
+
+		// when
+		List<Product> products = productService.findAllByQuery(productQuery);
+
+		// then
+		assertEquals(2, products.size());
+	}
+
+	@DisplayName("동적 쿼리 - 사용자와 날짜로 상품 조회")
+	@Test
+	void findAllByQueryMemberNameAndStartDateAndEndDate() {
+		// given
+		ProductFindDto.GetProductQuery productQuery = new ProductFindDto.GetProductQuery(null, "admin",
+			LocalDateTime.of(2020, 10, 10, 0, 0, 0),
+			LocalDateTime.of(2021, 10, 10, 0, 0, 0));
+
+		// when
+		List<Product> products = productService.findAllByQuery(productQuery);
+
+		// then
+		assertEquals(1, products.size());
+	}
+
+	@DisplayName("사용자 id로 상품 조회")
+	@Test
+	void findByUserId() {
+		// given
+		int memberId = 1;
+
+		// when
+		List<Product> product = productRepository.findAllByMemberMemberId(memberId);
+
+		// then
+		assertFalse(product.isEmpty());
+	}
+
+	@DisplayName("상품 이름으로 상품 조회")
+	@Test
+	void findByName() {
+		// given
+		String name = "Product 1";
+
+		// when
+		Product product = productRepository.findFirstByNameAndIsDeletedFalse(name).orElse(null);
+
+		// then
+		assertNotNull(product);
+	}
+}

--- a/src/test/java/dev/cass/knorda/domain/product/ProductRepositoryTest.java
+++ b/src/test/java/dev/cass/knorda/domain/product/ProductRepositoryTest.java
@@ -14,7 +14,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import dev.cass.knorda.api.product.dto.ProductFindDto;
-import dev.cass.knorda.api.product.service.ProductService;
 
 @Transactional
 @ActiveProfiles("test")
@@ -24,16 +23,6 @@ class ProductRepositoryTest {
 	@Autowired
 	private ProductRepository productRepository;
 
-	@Autowired
-	private ProductService productService;
-
-	/**
-	 * 동적 쿼리 테스트를 해야 하는데, mocking하다 보면 data.sql에 있는 데이터를 가져오지 못한다.
-	 * 그러면 beforeEach에서 데이터를 넣어주는 방법이 있지만, 그렇게 되면 테스트 코드가 너무 길어진다.
-	 * 그래서 일단 repositoryTest 클래스에서 테스트를 진행시켰는데, productServiceTest 클래스를 두 개를 작성해야 할지?
-	 * 동적 쿼리 부분을 따로 Repository 클래스로 분리하려고 해도, specification은 JpaSpecificationExecutor 인터페이스의 메소드를 호출해야 되기 때문에 순환참조가 일어날 것 같음?
-	 * 우선 동적 쿼리에 대한 테스트는 임시로 repositoryTest에 작성하고, 어떻게 변경할지 정할 예정
-	 */
 	@DisplayName("동적 쿼리 - 회원으로 상품 조회")
 	@Test
 	void findAllByQueryMemberName() {
@@ -41,7 +30,7 @@ class ProductRepositoryTest {
 		ProductFindDto.GetProductQuery productQuery = new ProductFindDto.GetProductQuery(null, "admin", null, null);
 
 		// when
-		List<Product> products = productService.findAllByQuery(productQuery);
+		List<Product> products = productRepository.findAll(ProductSpecification.searchProductQuery(productQuery));
 
 		// then
 		assertEquals(2, products.size());
@@ -54,7 +43,7 @@ class ProductRepositoryTest {
 		ProductFindDto.GetProductQuery productQuery = new ProductFindDto.GetProductQuery("Product 3", null, null, null);
 
 		// when
-		List<Product> products = productService.findAllByQuery(productQuery);
+		List<Product> products = productRepository.findAll(ProductSpecification.searchProductQuery(productQuery));
 
 		// then
 		assertEquals(1, products.size());
@@ -69,7 +58,7 @@ class ProductRepositoryTest {
 			LocalDateTime.of(2021, 10, 10, 0, 0, 0));
 
 		// when
-		List<Product> products = productService.findAllByQuery(productQuery);
+		List<Product> products = productRepository.findAll(ProductSpecification.searchProductQuery(productQuery));
 
 		// then
 		assertEquals(2, products.size());
@@ -84,7 +73,7 @@ class ProductRepositoryTest {
 			LocalDateTime.of(2021, 10, 10, 0, 0, 0));
 
 		// when
-		List<Product> products = productService.findAllByQuery(productQuery);
+		List<Product> products = productRepository.findAll(ProductSpecification.searchProductQuery(productQuery));
 
 		// then
 		assertEquals(1, products.size());

--- a/src/test/resources/db/h2/data.sql
+++ b/src/test/resources/db/h2/data.sql
@@ -7,3 +7,12 @@ INSERT INTO "member" (member_id, member_name, `password`, last_logged_in_at, is_
 VALUES (2, 'admin2', '62ccffd497a0657aed27250f175bccd4bf03d40a8e4f1404b62ea6b0858217d5', '2020-01-01 00:00:00', 0,
         'Administrator', '2020-01-01 00:00:00', '2020-01-01 00:00:00', 'admin');
 
+INSERT INTO "product" (product_id, member_id, name, image_url, description, is_deleted, created_at, modified_at)
+VALUES (1, 1, 'Product 1', 'https://via.placeholder.com/150', 'Product 1 Description', 0, '2020-01-01 00:00:00',
+        '2020-01-01 00:00:00');
+INSERT INTO "product" (product_id, member_id, name, image_url, description, is_deleted, created_at, modified_at)
+VALUES (2, 1, 'Product 2', 'https://via.placeholder.com/150', 'Product 2 Description', 0, '2021-01-01 00:00:00',
+        '2021-01-01 00:00:00');
+INSERT INTO "product" (product_id, member_id, name, image_url, description, is_deleted, created_at, modified_at)
+VALUES (3, 2, 'Product 3', 'https://via.placeholder.com/150', 'Product 2 Description', 0, '2021-01-01 00:00:00',
+        '2021-01-01 00:00:00');

--- a/src/test/resources/db/h2/schema.sql
+++ b/src/test/resources/db/h2/schema.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS "product";
 DROP TABLE IF EXISTS "member";
 CREATE TABLE "member"
 (
@@ -11,3 +12,18 @@ CREATE TABLE "member"
     `modified_at`       DATETIME            NOT NULL,
     `modified_by`       VARCHAR(20)         NOT NULL
 );
+
+CREATE TABLE "product"
+(
+    `product_id`  integer PRIMARY KEY NOT NULL AUTO_INCREMENT,
+    `member_id`   integer             NOT NULL,
+    `name`        varchar(200)        NOT NULL,
+    `image_url`   varchar(200),
+    `description` mediumtext          NOT NULL,
+    `is_deleted`  boolean             NOT NULL,
+    `created_at`  datetime            NOT NULL,
+    `modified_at` datetime            NOT NULL
+);
+
+ALTER TABLE "product"
+    ADD FOREIGN KEY (`member_id`) REFERENCES "member" (`member_id`);

--- a/src/test/resources/db/h2/schema.sql
+++ b/src/test/resources/db/h2/schema.sql
@@ -22,7 +22,8 @@ CREATE TABLE "product"
     `description` mediumtext          NOT NULL,
     `is_deleted`  boolean             NOT NULL,
     `created_at`  datetime            NOT NULL,
-    `modified_at` datetime            NOT NULL
+    `modified_at` datetime            NOT NULL,
+    CONSTRAINT `product_name` UNIQUE (`name`)
 );
 
 ALTER TABLE "product"


### PR DESCRIPTION
## 작업 내역 개요
Product 정보의 삽입/수정/삭제/조회 API, 여러 검색 조건을 선택적으로 사용 가능한 Product 목록 조회 API를 추가.  

- Product Entity를 생성하고, Member와의 연관관계 추가
	- 이에 따른 N+1 problem 을 방지하기 위해 list 조회 시 fetch join을 사용하도록 함
- Product CRUD 메소드 추가
- JPA Specification을 사용하는 동적 쿼리 추가
	- 보통은 쿼리가 복잡해지면 QueryDSL을 사용하게 되는데, 이후 복잡한 조회 쿼리가 더 추가되면 사용을 고려하는 것으로 하고 우선은 JPA만을 사용하여 구현하기로 결정함
- Product에 Facade 패턴을 사용하고, 이에 맞춰 사용할 수 있도록 MemberService에 Member 객체를 대신 리턴하는 조회 메소드를 일부 추가
- Product 이미지는 별도의 CRUD API를 구현할 예정
	- 이미지 업로드를 위해서는 form data로 받거나 URL 자체를 받아야 하는데, form data로 받으려면 다른 body 정보도 form data로 전송해야 하고, 이미지 처리에 시간이 걸릴 수 있기 때문에 API를 분리하는 것이 낫다고 판단함