### PR TITLE
[Chore] Naver Cloud 자동배포 action 추가

### DIFF
--- a/.github/workflows/navercloud-cd-test.yaml
+++ b/.github/workflows/navercloud-cd-test.yaml
@@ -1,0 +1,51 @@
+name: Naver Cloud CD Test
+
+on:
+  pull_request:
+    branches:
+      [ "feature/nc-cd" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Add application properties secret
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: ./src/main/resources/application.yaml
+        env:
+          encrypt.salt: ${{ secrets.ENCRYPT_SALT }}
+          spring.datasource.url: ${{ secrets.DB_URL_PROD }}
+          spring.datasource.username: ${{ secrets.DB_USERNAME_PROD }}
+          spring.datasource.password: ${{ secrets.DB_PASS_PROD }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: build
+
+      - name: Zip the build file
+        run: zip -r -qq -j ./knorda-test.zip ./build/libs/knorda-0.0.1-SNAPSHOT.jar
+
+      - name: Deliver to Naver Cloud
+        uses: prewk/s3-cp-action@v2
+        with:
+          aws_access_key_id: ${{ secrets.NC_API_KEY }}
+          aws_secret_access_key: ${{ secrets.NC_API_SECRET }}
+          source: './knorda-test.zip'
+          aws_s3_endpoint: 'https://kr.object.ncloudstorage.com'
+          dest: ${{ secrets.NC_BUCKET_DIR }}
+

--- a/.github/workflows/navercloud-cd-test.yaml
+++ b/.github/workflows/navercloud-cd-test.yaml
@@ -3,7 +3,7 @@ name: Naver Cloud CD Test
 on:
   push:
     branches:
-      [ "feature/nc-cd" ]
+      [ "main" ]
 
 jobs:
   build:
@@ -28,6 +28,7 @@ jobs:
           spring.datasource.url: ${{ secrets.DB_URL_PROD }}
           spring.datasource.username: ${{ secrets.DB_USERNAME_PROD }}
           spring.datasource.password: ${{ secrets.DB_PASS_PROD }}
+          server.port: ${{ secrets.SERVER_PORT_PROD }}
 
       - name: Add application test properties secrets
         uses: microsoft/variable-substitution@v1
@@ -56,3 +57,11 @@ jobs:
           aws_s3_endpoint: 'https://kr.object.ncloudstorage.com'
           dest: ${{ secrets.NC_BUCKET_DIR }}
 
+      - name: Trigger Naver Cloud Deploy
+        uses: cass07/navercloud-api@v2
+        with:
+          nc_api_uri: ${{ format('/api/v1/project/{0}/stage/{1}/scenario/{2}/deploy', secrets.NC_PROJECT_ID, secrets.NC_STAGE_ID, secrets.NC_SCENARIO_ID) }}
+          nc_api_base_url: 'https://vpcsourcedeploy.apigw.ntruss.com'
+          method: 'POST'
+          nc_access_key: ${{ secrets.NC_API_KEY }}
+          nc_secret_key: ${{ secrets.NC_API_SECRET }}

--- a/.github/workflows/navercloud-cd-test.yaml
+++ b/.github/workflows/navercloud-cd-test.yaml
@@ -1,7 +1,7 @@
 name: Naver Cloud CD Test
 
 on:
-  pull_request:
+  push:
     branches:
       [ "feature/nc-cd" ]
 

--- a/.github/workflows/navercloud-cd-test.yaml
+++ b/.github/workflows/navercloud-cd-test.yaml
@@ -29,6 +29,13 @@ jobs:
           spring.datasource.username: ${{ secrets.DB_USERNAME_PROD }}
           spring.datasource.password: ${{ secrets.DB_PASS_PROD }}
 
+      - name: Add application test properties secrets
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: ./src/test/resources/application-test.yaml
+        env:
+          encrypt.salt: ${{ secrets.ENCRYPT_SALT }}
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 


### PR DESCRIPTION
## 작업 내역 개요
Github Action을 통해, 빌드 파일을 서버에 업로드해서 자동으로 실행하는 액션을 추가

- 프로젝트를 빌드할 때, Github Action을 통해, yaml 파일에 실제 환경변수를 주입
- 프로젝트를 jar 파일로 빌드한 후, 이를 Object Storage에 업로드
- 업로드한 Object Storage의 파일을 통해, SourceDeploy를 사용하여 배포할 수 있도록 배포 프로젝트와 시나리오를 콘솔에서 추가
- Naver Cloud API를 사용해, 배포 시나리오의 배포 트리거링을 Github Action을 통해 수행
    - Naver Cloud API 호출 시 매 request마다 secret을 사용한 signature를 필요로 하기 때문에, 추후 다른 서비스의 API를 호출할 필요가 있을때 중복된 코드를 사용할 필요가 없도록 Github Action을 생성하여 이를 호출
    - [navercloud-api](https://github.com/Cass07/navercloud-api)
- [개발 기록](https://github.com/Cass07/TIL/blob/master/2024/12/20241214.md)

### 의문사항
- 모든 feature 브랜치의 코드는 PR시 테스트 과정을 마치고 나서 main branch에 merge되는데, 그렇다면 main 브랜치의 배포를 진행할 때, 굳이 다시 한 번 test를 진행해야 할 필요가 있는가?
    - 진행하는 것이 맞는 것으로 보이는데, 만약 테스트의 코스트가 크다면 생략하는 것도 도움이 되지 않을까 생각됩니다
